### PR TITLE
Add UI widget and supporting methods for local filter; Closes #2 #4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     trln_argon (0.1.0)
+      blacklight (~> 6.7)
       rails (~> 5.0.1)
 
 GEM
@@ -45,12 +46,36 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.4)
+    autoprefixer-rails (6.6.1)
+      execjs
+    blacklight (6.7.2)
+      bootstrap-sass (~> 3.2)
+      deprecation
+      globalid
+      kaminari (>= 0.15)
+      nokogiri (~> 1.6)
+      rails (>= 4.2, < 6)
+      rsolr (>= 1.0.6, < 3)
+      twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
+    bootstrap-sass (3.3.7)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     builder (3.2.2)
     concurrent-ruby (1.0.4)
+    deprecation (1.0.0)
+      activesupport
     erubis (2.7.0)
+    execjs (2.7.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
+    jquery-rails (4.2.2)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -91,6 +116,9 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
+    rsolr (1.1.2)
+      builder (>= 2.1.2)
+    sass (3.4.23)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -101,6 +129,10 @@ GEM
     sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.5)
+    twitter-typeahead-rails (0.11.1.pre.corejavascript)
+      actionpack (>= 3.1)
+      jquery-rails
+      railties (>= 3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     websocket-driver (0.6.4)

--- a/app/views/catalog/_local_filter.html.erb
+++ b/app/views/catalog/_local_filter.html.erb
@@ -1,0 +1,13 @@
+<% if @filtered_results_total > 0 %>
+  <% if local_filter_applied? %>
+    <%= link_to t("blacklight.local_filter.applied", consortium_name: consortium_long_name,
+                                                     filtered_results_total: @filtered_results_total,
+                                                     entry_name: entry_name(@filtered_results_total)),
+          url_for(search_state.to_h.merge(local_filter: 'false', page: '1')) %>
+  <% else %>
+    <%= link_to t("blacklight.local_filter.not_applied", local_institution_name: institution_long_name,
+                                                         filtered_results_total: @filtered_results_total,
+                                                         entry_name: entry_name(@filtered_results_total)),
+          url_for(search_state.to_h.merge(local_filter: 'true', page: '1')) %>
+  <% end %>
+<% end %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,0 +1,7 @@
+<div id="sortAndPerPage" class="clearfix">
+  <%= render :partial => "paginate_compact", :object => @response if show_pagination? %>
+
+  <%= render :partial => "local_filter" %>
+
+  <%= render_results_collection_tools wrapping_class: "search-widgets pull-right" %>
+</div>

--- a/config/initializers/trln_argon.rb
+++ b/config/initializers/trln_argon.rb
@@ -1,13 +1,19 @@
 config_file = File.join(Rails.root, "/config/trln_argon_config.yml")
 
+def apply_local_config (config, field)
+  config[field] if config[field]
+end
+
 if File.exist?(config_file)
 
   local_config = YAML.load_file(config_file)[Rails.env]
 
   TrlnArgon::Engine.configure do |config|
-    config.rollup_field           = local_config['rollup_field'] if local_config['rollup_field']
-    config.preferred_record_field = local_config['preferred_record_field'] if local_config['preferred_record_field']
-    config.preferred_record_value = local_config['preferred_record_value'] if local_config['preferred_record_value']
+    config.rollup_field                  = apply_local_config(local_config, 'rollup_field')
+    config.preferred_record_field        = apply_local_config(local_config, 'preferred_record_field')
+    config.preferred_record_value        = apply_local_config(local_config, 'preferred_record_value')
+    config.local_institution             = apply_local_config(local_config, 'local_institution')
+    config.apply_local_filter_by_default = apply_local_config(local_config, 'apply_local_filter_by_default')
   end
 
 end

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -1,8 +1,40 @@
 en:
 
-  blacklight:
+    blacklight:
 
-    home:
+        local_institution:
+            duke:
+                short_name: "Duke"
+                long_name: "Duke Libraries"
+            unc:
+                short_name: "UNC"
+                long_name: "UNC Libraries"
+            ncsu:
+                short_name: "NCSU"
+                long_name: "NCSU Libraries"
 
-        welcome: "Welcome to Search TRLN"
-        blurb: "Search TRLN provides a single search interface to the TRLN Libraries' Collections."
+
+        consortium:
+            short_name: "TRLN"
+            long_name: "TRLN Libraries"
+
+        home:
+
+            welcome: "Welcome to Search TRLN"
+            blurb: "Search TRLN provides a single search interface to the TRLN Libraries' Collections."
+
+        search:
+            pagination_info:
+                no_items_found: 'No %{filter_scope_name} %{entry_name} found'
+                single_item_found: '<strong>1</strong> %{filter_scope_name} %{entry_name} found'
+                pages:
+                    one: '<strong>%{start_num}</strong> - <strong>%{end_num}</strong> of <strong>%{total_num} %{filter_scope_name} %{entry_name}</strong>'
+                    other: '<strong>%{start_num}</strong> - <strong>%{end_num}</strong> of <strong>%{total_num} %{filter_scope_name} %{entry_name}</strong>'
+
+
+        entry_name:
+            default: 'result'
+
+        local_filter:
+            applied: "Show %{filtered_results_total} %{entry_name} at all %{consortium_name}"
+            not_applied: "Show %{filtered_results_total} %{entry_name} at %{local_institution_name}"

--- a/lib/generators/trln_argon/install_generator.rb
+++ b/lib/generators/trln_argon/install_generator.rb
@@ -17,8 +17,14 @@ module TrlnArgon
       copy_file "trln_argon_config.yml", "config/trln_argon_config.yml"
     end
 
-    def install_search_builder
-      copy_file "trln_search_builder.rb", "app/models/trln_search_builder.rb"
+    def install_search_builders
+      copy_file "search_builders/trln_search_builder.rb", "app/models/trln_search_builder.rb"
+      copy_file "search_builders/consortium_search_builder.rb", "app/models/consortium_search_builder.rb"
+    end
+
+    def install_helpers
+      copy_file "helpers/catalog_helper.rb", "app/helpers/catalog_helper.rb"
+      copy_file "helpers/trln_argon_helper.rb", "app/helpers/trln_argon_helper.rb"
     end
 
     def install_stylesheet
@@ -27,14 +33,9 @@ module TrlnArgon
 
     def inject_catalog_controller_overrides
       unless IO.read("app/controllers/catalog_controller.rb").include?('TrlnArgon')
-
         insert_into_file "app/controllers/catalog_controller.rb", :after => "include Blacklight::Marc::Catalog" do
           "\n\n  # CatalogController behavior and configuration for TrlnArgon"\
           "\n  include TrlnArgon::ControllerOverride\n"
-        end
-
-        insert_into_file "app/controllers/catalog_controller.rb", :after => "configure_blacklight do |config|" do
-          "\n\n    config.search_builder_class = TrlnSearchBuilder\n"
         end
       end
     end

--- a/lib/generators/trln_argon/templates/helpers/catalog_helper.rb
+++ b/lib/generators/trln_argon/templates/helpers/catalog_helper.rb
@@ -1,0 +1,5 @@
+module CatalogHelper
+  include Blacklight::CatalogHelperBehavior
+  include TrlnArgon::CatalogHelperBehavior
+
+end

--- a/lib/generators/trln_argon/templates/helpers/trln_argon_helper.rb
+++ b/lib/generators/trln_argon/templates/helpers/trln_argon_helper.rb
@@ -1,0 +1,4 @@
+module TrlnArgonHelper
+  include TrlnArgon::TrlnArgonHelperBehavior
+
+end

--- a/lib/generators/trln_argon/templates/search_builders/consortium_search_builder.rb
+++ b/lib/generators/trln_argon/templates/search_builders/consortium_search_builder.rb
@@ -1,0 +1,8 @@
+class ConsortiumSearchBuilder < Blacklight::SearchBuilder
+
+  include Blacklight::Solr::SearchBuilderBehavior
+  include TrlnArgon::TrlnSearchBuilderBehavior
+
+  self.default_processor_chain += [:rollup_duplicate_records]
+
+end

--- a/lib/generators/trln_argon/templates/search_builders/local_search_builder.rb
+++ b/lib/generators/trln_argon/templates/search_builders/local_search_builder.rb
@@ -1,0 +1,8 @@
+class LocalSearchBuilder < Blacklight::SearchBuilder
+
+  include Blacklight::Solr::SearchBuilderBehavior
+  include TrlnArgon::TrlnSearchBuilderBehavior
+
+  self.default_processor_chain += [:show_only_local_holdings]
+
+end

--- a/lib/generators/trln_argon/templates/trln_argon_config.yml
+++ b/lib/generators/trln_argon/templates/trln_argon_config.yml
@@ -2,6 +2,8 @@ defaults: &defaults
     rollup_field: "rollup_key"
     preferred_record_field: "institution"
     preferred_record_value: "duke"
+    local_institution: "duke"
+    apply_local_filter_by_default: "true"
 
 development:
   <<: *defaults

--- a/lib/generators/trln_argon/templates/trln_argon_helper.rb
+++ b/lib/generators/trln_argon/templates/trln_argon_helper.rb
@@ -1,0 +1,4 @@
+module TrlnArgonHelper
+  include TrlnArgon::TrlnArgonHelperBehavior
+
+end

--- a/lib/generators/trln_argon/templates/trln_search_builder.rb
+++ b/lib/generators/trln_argon/templates/trln_search_builder.rb
@@ -1,8 +1,0 @@
-class TrlnSearchBuilder < Blacklight::SearchBuilder
-
-  include Blacklight::Solr::SearchBuilderBehavior
-  include TrlnArgon::TrlnSearchBuilderBehavior
-
-  # self.default_processor_chain += [:rollup_duplicate_records]
-
-end

--- a/lib/trln_argon.rb
+++ b/lib/trln_argon.rb
@@ -2,6 +2,8 @@ require "trln_argon/engine"
 require 'trln_argon/version'
 
 module TrlnArgon
+  require 'trln_argon/helpers/catalog_helper_behavior'
+  require 'trln_argon/helpers/trln_argon_helper_behavior'
   require 'trln_argon/controller_override'
   require 'trln_argon/trln_search_builder_behavior'
 end

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -4,9 +4,87 @@ module TrlnArgon
 
     included do
 
+      before_action :local_filter_session
+      before_action :search_builder_class
+      before_action :filtered_results_total, only: :index
+
+      helper_method :local_filter_applied?
+
       # TRLN Argon CatalogController configurations
       configure_blacklight do |config|
+
+        # TODO: Consider making some of this configurabl in trln_argon_config.yml
         config.default_per_page = 20
+      end
+
+
+      private
+
+      def filtered_results_total
+        @filtered_results_total = filtered_results_query_response['response']['numFound']
+      end
+
+      def filtered_results_query_response
+        filtered_response = repository.search(filtered_results_search_builder.with(search_state.to_h))
+      end
+
+      def filtered_results_search_builder
+        if local_filter_applied?
+          ConsortiumSearchBuilder.new(CatalogController)
+        else
+          LocalSearchBuilder.new(CatalogController)
+        end
+      end
+
+      def search_builder_class
+        if local_filter_applied?
+          blacklight_config.search_builder_class = LocalSearchBuilder
+        else
+          blacklight_config.search_builder_class = ConsortiumSearchBuilder
+        end
+      end
+
+      def local_filter_session
+        if local_filter_param_present?
+          set_local_filter_session_from_param
+        elsif local_filter_session_set?
+          set_local_filter_param_from_session
+        else
+          set_local_filter_param_and_session_to_default
+        end
+      end
+
+      def local_filter_param_present?
+        local_filter_whitelist.include?(params[:local_filter])
+      end
+
+      def local_filter_session_set?
+        local_filter_whitelist.include?(session[:local_filter])
+      end
+
+      def set_local_filter_session_from_param
+        session[:local_filter] = params[:local_filter]
+      end
+
+      def set_local_filter_param_from_session
+        params[:local_filter] = session[:local_filter]
+      end
+
+      def set_local_filter_param_and_session_to_default
+        session[:local_filter] = local_filter_default
+        params[:local_filter] = local_filter_default
+      end
+
+      def local_filter_whitelist
+        ['true', 'false']
+      end
+
+      def local_filter_applied?
+        session[:local_filter] == 'true'
+      end
+
+      def local_filter_default
+        TrlnArgon::Engine.configuration.apply_local_filter_by_default
       end
 
     end

--- a/lib/trln_argon/engine.rb
+++ b/lib/trln_argon/engine.rb
@@ -20,12 +20,16 @@ module TrlnArgon
 
       attr_accessor :rollup_field,
                     :preferred_record_field,
-                    :preferred_record_value
+                    :preferred_record_value,
+                    :local_institution,
+                    :apply_local_filter_by_default,
 
       def initialize
-        @rollup_field           = "rollup_key"
-        @preferred_record_field = "institution"
-        @preferred_record_value = "duke"
+        @rollup_field                  = "rollup_key"
+        @preferred_record_field        = "institution"
+        @preferred_record_value        = "duke"
+        @local_institution             = "duke"
+        @apply_local_filter_by_default = "true"
       end
 
     end

--- a/lib/trln_argon/helpers/catalog_helper_behavior.rb
+++ b/lib/trln_argon/helpers/catalog_helper_behavior.rb
@@ -1,0 +1,61 @@
+module TrlnArgon
+  module CatalogHelperBehavior
+
+    ##
+    # This overrides Blacklight's override to add filter_scope_name to the paging information
+    ##
+    # Override the Kaminari page_entries_info helper with our own, blacklight-aware
+    # implementation.
+    # Displays the "showing X through Y of N" message.
+    #
+    # @param [RSolr::Resource] collection (or other Kaminari-compatible objects)
+    # @return [String]
+    def page_entries_info(collection, options = {})
+      return unless show_pagination? collection
+
+      entry_name = if options[:entry_name]
+        options[:entry_name]
+      elsif collection.respond_to? :model  # DataMapper
+        collection.model.model_name.human.downcase
+      elsif collection.respond_to?(:model_name) && !collection.model_name.nil? # AR, Blacklight::PaginationMethods
+        collection.model_name.human.downcase
+      else
+        t('blacklight.entry_name.default')
+      end
+
+      entry_name = entry_name.pluralize unless collection.total_count == 1
+
+      # grouped response objects need special handling
+      end_num = if collection.respond_to?(:groups) && render_grouped_response?(collection)
+        collection.groups.length
+      else
+        collection.limit_value
+      end
+
+      end_num = if collection.offset_value + end_num <= collection.total_count
+        collection.offset_value + end_num
+      else
+        collection.total_count
+      end
+
+      case collection.total_count
+        when 0
+          t('blacklight.search.pagination_info.no_items_found', :entry_name => entry_name,
+                                                                :filter_scope_name => filter_scope_name).html_safe
+        when 1
+          t('blacklight.search.pagination_info.single_item_found', :entry_name => entry_name,
+                                                                   :filter_scope_name => filter_scope_name).html_safe
+        else
+          t('blacklight.search.pagination_info.pages', :entry_name => entry_name,
+                                                       :filter_scope_name => filter_scope_name,
+                                                       :current_page => collection.current_page,
+                                                       :num_pages => collection.total_pages,
+                                                       :start_num => number_with_delimiter(collection.offset_value + 1),
+                                                       :end_num => number_with_delimiter(end_num),
+                                                       :total_num => number_with_delimiter(collection.total_count),
+                                                       :count => collection.total_pages).html_safe
+      end
+
+    end
+  end
+end

--- a/lib/trln_argon/helpers/trln_argon_helper_behavior.rb
+++ b/lib/trln_argon/helpers/trln_argon_helper_behavior.rb
@@ -1,0 +1,30 @@
+module TrlnArgon
+  module TrlnArgonHelperBehavior
+
+    def entry_name(count)
+      entry = t("blacklight.entry_name.default")
+      count.to_int == 1 ? entry : entry.pluralize
+    end
+
+    def institution_short_name
+      t("blacklight.local_institution.#{TrlnArgon::Engine.configuration.local_institution}.short_name")
+    end
+
+    def institution_long_name
+      t("blacklight.local_institution.#{TrlnArgon::Engine.configuration.local_institution}.long_name")
+    end
+
+    def consortium_short_name
+      t("blacklight.consortium.short_name")
+    end
+
+    def consortium_long_name
+      t("blacklight.consortium.long_name")
+    end
+
+    def filter_scope_name
+      local_filter_applied? ? institution_short_name : consortium_short_name
+    end
+
+  end
+end

--- a/lib/trln_argon/trln_search_builder_behavior.rb
+++ b/lib/trln_argon/trln_search_builder_behavior.rb
@@ -1,6 +1,11 @@
 module TrlnArgon
   module TrlnSearchBuilderBehavior
 
+    def show_only_local_holdings(solr_parameters)
+      solr_parameters[:fq] ||= []
+      solr_parameters[:fq] << local_holdings_query
+    end
+
     def rollup_duplicate_records(solr_parameters)
       solr_parameters[:fq] ||= []
       solr_parameters[:fq] << record_rollup_query
@@ -9,10 +14,20 @@ module TrlnArgon
     private
 
     def record_rollup_query
-      "{!collapse field=#{TrlnArgon::Engine.configuration.rollup_field} "\
-      "nullPolicy=expand "\
-      "max=termfreq(#{TrlnArgon::Engine.configuration.preferred_record_field},"\
-      "\"#{TrlnArgon::Engine.configuration.preferred_record_value}\")}"
+      # TODO: Placeholder for query that will rollup duplicate records:
+      #
+      # "{!collapse field=#{TrlnArgon::Engine.configuration.rollup_field} "\
+      # "nullPolicy=expand "\
+      # "max=termfreq(#{TrlnArgon::Engine.configuration.preferred_record_field},"\
+      # "\"#{TrlnArgon::Engine.configuration.preferred_record_value}\")}"
+    end
+
+    def local_holdings_query
+      "language_facet:English" # Arbitrary filter query to test local filter
+
+      # TODO: Placeholder for query that will limit results to local holdings:
+      #
+      # "institution_field:#{TrlnArgon::Engine.configuration.local_institution}"
     end
 
   end


### PR DESCRIPTION
This adds some of the UI elements and methods needed to support a local filter toggle that will switch between local and rolled up TRLN results. The details of the local filter and rollup queries are TBD since I'm not sure what the fields are yet. It could use some tests, but I'll get rspec added with some tests in a separate pull request.