### PR TITLE
Initial support for fetching and displaying Syndetics data

### DIFF
--- a/app/helpers/trln_argon/application_helper.rb
+++ b/app/helpers/trln_argon/application_helper.rb
@@ -1,4 +1,17 @@
 module TrlnArgon
   module ApplicationHelper
+    SIZES = Hash.new('SC.GIF').update(small: 'SC.GIF',
+                                      medium: 'MC.GIF',
+                                      large: 'LC.GIF').freeze
+    def cover_image(doc, options = { client: 'trlnet', size: 'small' })
+      isbn = doc.fetch('isbn_number_a', ['']).first
+      oclc = doc.fetch('oclc_number', '')
+      q = { isbn: "#{isbn}/#{SIZES[options[:size]]}",
+            oclc: oclc,
+            client: options[:client] }.to_query
+      URI::HTTP.build(host: 'www.syndetics.com',
+                      path: '/index.aspx',
+                      query: q).to_s
+    end
   end
 end

--- a/app/views/catalog/_show_summary_default.html.erb
+++ b/app/views/catalog/_show_summary_default.html.erb
@@ -1,0 +1,10 @@
+ <div class="syndetics_junk">
+  	<% enhanced_data(@document) do |s| %>
+  	  <% if s.summary? %>
+       <section class="summary">
+        <header>Summary</header>
+  	    <%= s.summary.html_safe %>
+      </section>
+  	  <% end %>
+  	<% end %>
+  </div>

--- a/lib/trln_argon.rb
+++ b/lib/trln_argon.rb
@@ -5,6 +5,7 @@ module TrlnArgon
   autoload :Lookups, 'trln_argon/mappings'
   autoload :LookupManager, 'trln_argon/mappings'
   autoload :MappingsGitFetcher, 'trln_argon/mappings'
+  autoload :SyndeticsData, 'trln_argon/syndetics_data'
   require 'trln_argon/controller_override'
   require 'trln_argon/field'
   require 'trln_argon/fields'

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -31,7 +31,7 @@ module TrlnArgon
         config.document_solr_path = :document
         config.document_solr_request_handler = nil
 
-        config.show.partials = %i[show_header show_thumbnail show show_items]
+        config.show.partials = %i[show_header show_thumbnail show show_summary show_items]
 
         # Set partials to render
         config.index.partials = %i[index_header thumbnail index index_items]

--- a/lib/trln_argon/field.rb
+++ b/lib/trln_argon/field.rb
@@ -1,6 +1,6 @@
 module TrlnArgon
   class Field < SimpleDelegator
-    attr_reader :solr_name, :labels, :label
+    attr_reader :solr_name, :labels
 
     def initialize(solr_name, labels)
       @solr_name = solr_name.to_s

--- a/lib/trln_argon/helpers/trln_argon_helper_behavior.rb
+++ b/lib/trln_argon/helpers/trln_argon_helper_behavior.rb
@@ -28,6 +28,29 @@ module TrlnArgon
                        query: q).to_s
     end
 
+    def enhanced_data_url(query)
+      URI::HTTPS.build(host: 'syndetics.com',
+                       path: '/index.php',
+                       query: query).to_s
+    end
+
+    def enhanced_data(doc, options = { client: 'trlnet' })
+      isbns = doc.fetch('isbn_number_a', [])
+      isbns[0] = "#{isbns[0]}/XML.XML"
+      oclc = doc.fetch('oclc_number', '')
+      # to_query puts [] at the end of params, which syndetics doesn't want
+      q = { isbn: isbns, oclc: oclc, client: options[:client] }.to_query.gsub(/%5B%5D/, '')
+      data = nil
+      begin
+        doc_xml = Faraday.get(enhanced_data_url(q)).body
+        data = TrlnArgon::SyndeticsData.new(Nokogiri::XML(doc_xml))
+      rescue StandardError => e
+        logger.warn("unable to fetch syndetics data for #{q}: #{e}")
+      end
+      yield data if block_given? && !data.nil?
+      data
+    end
+
     def institution_code_to_short_name(options = {})
       options[:value].map do |val|
         t("trln_argon.institution.#{val}.short_name", default: val)

--- a/lib/trln_argon/syndetics_data.rb
+++ b/lib/trln_argon/syndetics_data.rb
@@ -1,0 +1,172 @@
+module TrlnArgon
+  module XMLHandler; end
+
+  # encapsulation of various kinds of enriched catalog data from Syndetics,
+  # including cover images, tables of contents, summaries, author notes,
+  # reviews and track listings for AV materials.
+  #
+  # In general, for each kinds of data two methods exist, one with a ? at
+  # the end to determine whether the data is present, and
+  # another to fetch the data (usually HTML, but sometimes plain text or a URL)
+  #
+  # See the names of the ELEMENTS constant for furhter details.
+  class SyndeticsData
+    include XMLHandler
+    COVERS = { SC: 'small', MC: 'medium', LC: 'large' }.freeze
+
+    def self.read_stylesheet(name)
+      File.read(File.join(File.dirname(__FILE__), 'xslt', "#{name}.xsl"))
+    end
+
+    def self.compile_stylesheet(xslt_string)
+      Nokogiri::XSLT.parse(xslt_string)
+    end
+
+    def self.transform_element(xslt, element)
+      doc = Nokogiri::XML::Document.new
+      doc.root = element
+      xslt.transform(doc).serialize.strip
+    end
+
+    def self.transform_toc(tocelement)
+      @@toc_xslt ||= compile_stylesheet(read_stylesheet('toc'))
+      transform_element(@@toc_xslt, tocelement)
+    end
+
+    def self.transform_avreview(avelement)
+      @@avreview_xslt ||= compile_stylesheet(read_stylesheet('av-review'))
+      transform_element(@@avreview_xslt, avelement)
+    end
+
+    def self.transform_avtracklist(avelement)
+      @@avtracklist_xslt ||= compile_stylesheet(read_stylesheet('av-tracks'))
+      transform_element(@@avtracklist_xslt, avelement)
+    end
+
+    # some fields have a wall of text; this tries to find places
+    # that should be line breaks
+    # wraps each chunk in <p> tags
+    def post_process_bigtext(txt)
+      # multiple nbsp surrounded by spaces
+      result = txt.split(/\s+\du00ao+\s+/).map { |x| "<p>#{x.strip}</p>" }.join(' ')
+      # sometimes there are <p> tags already in there ...
+      result.gsub(%r{(<\/?p>){2,}}, '\1')
+    end
+
+    # indication of which elements we can query and extract.  This is a sort
+    # of DSL; the hash corresponding to each element name will contain
+    # at least :element, which is the top level element that must be required
+    # for the query method to match the input document.
+    # :path indicates the element to be extracted for a simple text extraction,
+    # :path_required indicates that :path must be present for the query method
+    # IN ADDITION TO :element, if the query method matches the input document.
+    # :bigtext indicates that the field is often simple text, but might be long
+    # and not have line breaks, in which case we will try to output it as a
+    # set of paragraphs.
+    # :transformer if present, a proc/block/method that should be invoked on a 
+    # document rooted at :element to extract the content.
+    ELEMENTS = {
+      summary: {
+        element: 'SUMMARY',
+        path: './/Fld520',
+        bigtext: true
+      },
+      toc: {
+        element: 'TOC',
+        transformer: method(:transform_toc)
+      },
+      authornotes: {
+        element: 'ANOTES',
+        path: 'VarDFlds/SSIFlds/Fld980',
+        bigtext: true
+      },
+      samplechapter: {
+        element: 'DBCHAPTER',
+        path: './/Fld520',
+        bigtext: true
+      },
+      avsummary: {
+        element: 'AVSUMMARY',
+        path: '//SSIFlds/Fld520'
+      },
+      avreview: {
+        element: 'AVSUMMARY',
+        path: 'AVSUMMARY[//Fld520|//Fld500]',
+        path_required: true,
+        transformer: method(:transform_avreview)
+      },
+      avtracklist: {
+        element: 'AVSUMMARY',
+        path: 'AVSUMMARY//Fld970[1]',
+        path_required: true,
+        transformer: method(:transform_avtracklist)
+      },
+      smallcover: {
+        element: 'SC',
+        path: 'text()'
+      },
+      medcover: {
+        element: 'MC',
+        path: 'text()'
+      },
+      lgcover: {
+        element: 'LC',
+        path: 'text()'
+      }
+    }.freeze
+
+    # dynamically create query and extract methods
+    ELEMENTS.each do |attr, data|
+      define_method :"#{attr.to_s}?" do
+        return false unless @present.include?(data[:element])
+        data[:path_required] ? !@doc.root.xpath(data[:path]).first.nil? : true
+      end
+
+      define_method :"#{attr.to_s}" do
+        return '' unless @present.include?(data[:element])
+        data_element = @doc.root.xpath(data[:element]).first
+        return data[:transformer].call(data_element) if data[:transformer]
+        return '' if data_element.nil?
+        element_data = data_element.xpath(data[:path])
+        unless element_data.nil?
+          result = element_data.first.text
+          return data[:bigtext] ? post_process_bigtext(result) : result
+        end
+        ''
+      end
+    end
+
+    def initialize(doc)
+      @doc = doc
+      @covers = Hash[COVERS.map do |elname, size|
+        txt = doc.xpath("#{elname}/text()").first
+        [size, txt.text] if txt
+      end]
+      @present = doc.root.children.map(&:name)
+    end
+
+    # custom methods that have to dig a bit deeper than looking for a top level element
+    #def avreview?
+      # summary contains a review if we have a 500 or 520 field under VarDFlds
+      # XSLT handles both cases
+    #  avsummary? && @doc.root.xpath('AVSUMMARY[//Fld520|//Fld500]|AVSUMMARY[//Fld500]').first
+    #end
+
+    #def avtracklist?
+      # summary contains a track list if we have a 970 under SSIFlds
+    #  avsummary? && @doc.root.xpath('AVSUMMARY[//Fld970]').first
+    #end
+
+    #def avreview
+    #  el = avreview?
+    #  return '' unless el
+    #  SyndeticsData.transform_avreview(el)
+    #end
+
+    #def avtracklist
+    #  el = avtracklist?
+    #  return '' unless el
+    #  SyndeticsData.transform_avtracklist(el)
+    #end
+  end
+end

--- a/lib/trln_argon/syndetics_data.rb
+++ b/lib/trln_argon/syndetics_data.rb
@@ -144,7 +144,7 @@ module TrlnArgon
       @covers = Hash[COVERS.map do |elname, size|
         txt = doc.xpath("#{elname}/text()").first
         [size, txt.text] if txt
-      end]
+      end.select(&:itself)]
       @present = doc.root.children.map(&:name)
     end
   end

--- a/lib/trln_argon/xslt/av-review.xsl
+++ b/lib/trln_argon/xslt/av-review.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+	<xsl:output omit-xml-declaration="yes" method="html" indent="yes" encoding="UTF-8"/>
+	<xsl:template match="AVSUMMARY">
+		<!-- display the summary portion (Syndetics assures us that an AVSUMMARY nodeset has either a Fld500 *or* a Fld520, but not both), as long as the summary doesn't consist solely of a copyright notice -->
+		<xsl:variable name="summary-data" select="//Notes/Fld520/a|//Notes/Fld500/a"/>
+		<xsl:if test="not(substring(normalize-space($summary-data),1,9) = 'Copyright')">
+			<section class="avReview">
+				<p>
+					<xsl:apply-templates select="$summary-data" mode="structured" />
+				</p>
+				<xsl:call-template name="copyright-generator" />
+			</section>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template match="a">
+		<!-- this template does a copy-of to preserve HTML elements in the <a> node -->
+		<xsl:if test="descendant-or-self::node()/text()">
+			<xsl:copy-of select="child::node()"/>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template name="copyright-generator">
+		<div>
+			<xsl:attribute name="class">syndeticscopyrightblock</xsl:attribute>
+			<xsl:text>Content provided by Syndetic Solutions, Inc.  </xsl:text>
+			<xsl:call-template name="hyperlink-generator">
+				<xsl:with-param name="href" select="'http://syndetics.com/termsofuse.htm'" />
+				<xsl:with-param name="link-text" select="'Terms of Use'" />
+				<xsl:with-param name="external-link-indicator" select="'yes'" />
+			</xsl:call-template>
+		</div>
+	</xsl:template>
+	<xsl:template name="hyperlink-generator">
+		<xsl:param name="href" />
+		<xsl:param name="link-text" />
+		<xsl:param name="external-link-indicator" />
+		<a>
+			<xsl:attribute name="href">
+				<xsl:value-of select="$href"/>
+			</xsl:attribute>
+			<xsl:if test="$external-link-indicator = 'yes'">
+				<xsl:attribute name="class">externallink</xsl:attribute>
+			</xsl:if>
+			<xsl:copy-of select="$link-text"/>
+		</a>
+	</xsl:template>
+</xsl:stylesheet>

--- a/lib/trln_argon/xslt/av-tracks.xsl
+++ b/lib/trln_argon/xslt/av-tracks.xsl
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+	<xsl:output omit-xml-declaration="yes" method="html" indent="yes" encoding="UTF-8"/>
+	<xsl:template match="/AVSUMMARY">
+		<xsl:variable name="av-tracks" select="//SSIFlds/Fld970" />
+		<xsl:if test="$av-tracks">
+			<section class="avTracks">
+				<p class="shaded label">Tracks</p>
+                <ul class="syndeticstoclist">
+                    <xsl:apply-templates select="$av-tracks"/>
+                </ul>
+                <xsl:call-template name="copyright-generator" />
+			</section>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template match="a" mode="structured">
+		<!-- this template does a copy-of to preserve HTML elements in the <a> node -->
+		<xsl:if test="descendant-or-self::node()/text()">
+			<xsl:copy-of select="child::node()"/>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template match="Fld970">
+		<xsl:if test="l/text() or t/text()">
+			<li class="leveltwo">
+				<xsl:if test="l/text()">
+					<xsl:value-of select="concat(l, '. ')"/>
+				</xsl:if>
+				<xsl:if test="t/text()">
+					<xsl:value-of select="t"/>
+				</xsl:if>
+			</li>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="copyright-generator">
+		<div class="syndeticscopyrightblock">
+            Content provided by Syndetic Solutions, Inc.
+            <xsl:call-template name="hyperlink-generator">
+				<xsl:with-param name="href" select="'http://syndetics.com/termsofuse.htm'" />
+				<xsl:with-param name="link-text" select="'Terms of Use'" />
+				<xsl:with-param name="external-link-indicator" select="'yes'" />
+			</xsl:call-template>
+		</div>
+	</xsl:template>
+
+	<xsl:template name="hyperlink-generator">
+		<xsl:param name="href" />
+		<xsl:param name="link-text" />
+		<xsl:param name="external-link-indicator" />
+		<a>
+			<xsl:attribute name="href">
+				<xsl:value-of select="$href"/>
+			</xsl:attribute>
+			<xsl:if test="$external-link-indicator = 'yes'">
+				<xsl:attribute name="class">externallink</xsl:attribute>
+			</xsl:if>
+			<xsl:copy-of select="$link-text"/>
+		</a>
+	</xsl:template>
+</xsl:stylesheet>

--- a/lib/trln_argon/xslt/toc.xsl
+++ b/lib/trln_argon/xslt/toc.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="html" indent="yes" omit-xml-declaration="yes"
+        encoding='utf-8' />
+
+    <xsl:template match="/">
+        <xsl:apply-templates match="VarFlds/VarDFlds/SSIFlds"/>
+    </xsl:template>
+
+    <xsl:template match="text()|@*"/>
+    <xsl:template match='SSIFlds'>
+   <ul class='toc'>
+     <xsl:for-each select='Fld970'>
+       <li>
+           <xsl:apply-templates select="l|t|p"/>
+       </li>
+    </xsl:for-each>
+   </ul>
+  </xsl:template>
+
+   <xsl:template match="l">
+     <span class="toc-element-number">
+      <xsl:value-of select="."/>
+  </span>
+  <xsl:text>&#160;</xsl:text>
+  </xsl:template>
+  <xsl:template match="t">
+     <span class="toc-element-title">
+       <xsl:value-of select="."/>
+   </span>
+  </xsl:template>
+
+  <xsl:template match="p">
+      <xsl:text>&#160;</xsl:text>
+    <span class="toc-element-pagerange">
+       <xsl:value-of select='.'/>
+     </span>
+  </xsl:template>
+</xsl:stylesheet>

--- a/spec/features/full_records_spec.rb
+++ b/spec/features/full_records_spec.rb
@@ -1,5 +1,5 @@
 describe 'full records' do
-  context 'displays multiple fields from the record' do
+  context 'when it displays multiple fields from the record' do
     before { visit solr_document_path(id: 'DUKE002960043') }
 
     it 'displays the title field label' do

--- a/spec/features/search_options_spec.rb
+++ b/spec/features/search_options_spec.rb
@@ -1,5 +1,5 @@
 describe 'search options' do
-  context 'search dropdown' do
+  context 'when displaying search dropdown' do
     before { visit search_catalog_path }
 
     it 'provides a dropdown with fielded search options' do

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -1,5 +1,5 @@
 describe 'search results' do
-  context 'no results found' do
+  context 'when no results found' do
     it 'displays a message for no results found' do
       visit search_catalog_path
       fill_in 'q', with: 'qwertyuiopasdfdghjklzxcvbnm'
@@ -8,7 +8,7 @@ describe 'search results' do
     end
   end
 
-  context 'some results found' do
+  context 'when some results found' do
     it 'displays the number of results found' do
       visit search_catalog_path
       fill_in 'q', with: 'food'
@@ -17,7 +17,7 @@ describe 'search results' do
     end
   end
 
-  context 'all results' do
+  context 'when showing all results' do
     def result_count
       visit search_catalog_path(local_filter: 'false')
       click_button 'search'
@@ -40,7 +40,7 @@ describe 'search results' do
     end
   end
 
-  context 'facets applied to search' do
+  context 'when facets applied to search' do
     before do
       visit search_catalog_path(local_filter: 'false')
       click_button 'search'

--- a/spec/helpers/trln_argon_helper_spec.rb
+++ b/spec/helpers/trln_argon_helper_spec.rb
@@ -3,7 +3,7 @@ require 'uri'
 
 describe TrlnArgonHelper do
   describe '#institution_code_to_short_name' do
-    context 'code has a translation' do
+    context 'when code has a translation' do
       let(:options) { { value: %w[unc duke ncsu] } }
 
       it 'uses the translated value' do
@@ -11,7 +11,7 @@ describe TrlnArgonHelper do
       end
     end
 
-    context 'code does not have a translation' do
+    context 'when code does not have a translation' do
       let(:options) { { value: ['pie'] } }
 
       it 'uses the default value' do
@@ -21,7 +21,7 @@ describe TrlnArgonHelper do
   end
 
   describe '#auto_link_values' do
-    context 'has a single link' do
+    context 'when it has a single link' do
       let(:options) { { value: ['https://library.duke.edu'] } }
 
       it 'returns a single linked value' do
@@ -30,7 +30,7 @@ describe TrlnArgonHelper do
       end
     end
 
-    context 'has more than one link' do
+    context 'when it has more than one link' do
       let(:options) { { value: ['https://library.duke.edu', 'https://www.lib.ncsu.edu'] } }
 
       it 'returns a single linked value' do
@@ -41,7 +41,7 @@ describe TrlnArgonHelper do
       end
     end
 
-    context 'has a link and then something that is not a link' do
+    context 'when it has a link and then something that is not a link' do
       let(:options) { { value: ['https://library.duke.edu', 'Soup'] } }
 
       it 'returns a linked value and a non-linked value' do
@@ -52,13 +52,13 @@ describe TrlnArgonHelper do
   end
 
   describe '#entry_name' do
-    context 'count is 1' do
+    context 'when count is 1' do
       it 'does not pluralize the entry name' do
         expect(helper.entry_name(1)).to eq('result')
       end
     end
 
-    context 'count is more than 1' do
+    context 'when count is more than 1' do
       it 'pluralizes the entry name' do
         expect(helper.entry_name(2)).to eq('results')
       end
@@ -90,7 +90,7 @@ describe TrlnArgonHelper do
   end
 
   describe '#filter_scope_name' do
-    context 'scope is BookmarksController' do
+    context 'when the scope is BookmarksController' do
       before { allow(helper).to receive(:controller_name).and_return('bookmarks') }
 
       it 'uses the translated scope name for bookmarks' do
@@ -98,7 +98,7 @@ describe TrlnArgonHelper do
       end
     end
 
-    context 'local filter is applied', verify_stubs: false do
+    context 'when local filter is applied', verify_stubs: false do
       before do
         allow(helper).to receive(:controller_name).and_return('catalog')
         allow(helper).to receive(:local_filter_applied?).and_return(true)
@@ -109,7 +109,7 @@ describe TrlnArgonHelper do
       end
     end
 
-    context 'local filter is not applied', verify_stubs: false do
+    context 'when local filter is not applied', verify_stubs: false do
       before do
         allow(helper).to receive(:controller_name).and_return('catalog')
         allow(helper).to receive(:local_filter_applied?).and_return(false)
@@ -122,7 +122,7 @@ describe TrlnArgonHelper do
   end
 
   describe '#url_href_with_url_text_link' do
-    context 'single link without text' do
+    context 'when we show single link without text' do
       let(:document) do
         SolrDocument.new(
           id: 'DUKE12345'
@@ -140,7 +140,7 @@ describe TrlnArgonHelper do
       end
     end
 
-    context 'single link with text' do
+    context 'when we show a single link with text' do
       let(:document) do
         SolrDocument.new(
           id:         'DUKE12345',
@@ -159,7 +159,7 @@ describe TrlnArgonHelper do
       end
     end
 
-    context 'multiple links each without a text value' do
+    context 'when we render multiple links each without a text value' do
       let(:document) do
         SolrDocument.new(
           id: 'DUKE12345'
@@ -181,7 +181,7 @@ describe TrlnArgonHelper do
       end
     end
 
-    context 'multiple links each with a text value' do
+    context 'when there are multiple links each with a text value' do
       let(:document) do
         SolrDocument.new(
           id: 'DUKE12345',
@@ -206,7 +206,7 @@ describe TrlnArgonHelper do
       end
     end
 
-    context 'multiple links with a different number of text values' do
+    context 'when there are multiple links with a different number of text values' do
       let(:document) do
         SolrDocument.new(
           id: 'DUKE12345',
@@ -232,7 +232,7 @@ describe TrlnArgonHelper do
   end
 
   describe '#cover_image' do
-    context 'link to a Syndetics cover image with various options' do
+    context 'when we link to a Syndetics cover image with various options' do
       let(:oclc) do
         '123098080985'
       end

--- a/spec/lib/trln_argon/solr_document_spec.rb
+++ b/spec/lib/trln_argon/solr_document_spec.rb
@@ -5,7 +5,7 @@ describe TrlnArgon::SolrDocument do
   end
 
   describe 'availability' do
-    context 'availability is set on the document' do
+    context 'when availability is set on the document' do
       let(:solr_document) do
         SolrDocumentTestClass.new(
           id: 'NCSU12345',
@@ -18,7 +18,7 @@ describe TrlnArgon::SolrDocument do
       end
     end
 
-    context 'availability is not set on the document' do
+    context 'when availability is not set on the document' do
       let(:solr_document) do
         SolrDocumentTestClass.new(
           id: 'NCSU12345'

--- a/spec/lib/trln_argon/trln_search_builder_behavior_spec.rb
+++ b/spec/lib/trln_argon/trln_search_builder_behavior_spec.rb
@@ -14,7 +14,7 @@ describe TrlnArgon::TrlnSearchBuilderBehavior do
   before { allow(context).to receive(:blacklight_config).and_return(blacklight_config) }
 
   describe 'apply_local_filter' do
-    context 'local filter is applied' do
+    context 'when local filter is applied' do
       let(:builder_with_params) { search_builder.with(local_filter: 'true') }
 
       before { builder_with_params.apply_local_filter(solr_parameters) }
@@ -26,7 +26,7 @@ describe TrlnArgon::TrlnSearchBuilderBehavior do
       end
     end
 
-    context 'local filter is not applied' do
+    context 'when local filter is not applied' do
       let(:builder_with_params) { search_builder.with(local_filter: 'false') }
 
       before { builder_with_params.apply_local_filter(solr_parameters) }
@@ -60,7 +60,7 @@ describe TrlnArgon::TrlnSearchBuilderBehavior do
   describe 'boost_isxn_matches' do
     before { builder_with_params.boost_isxn_matches(solr_parameters) }
 
-    context 'all fields search contains an issn search' do
+    context 'when all fields search contains an issn search' do
       let(:builder_with_params) { search_builder.with(q: '03431258') }
 
       it 'sets the isxn_ns_v parameter' do
@@ -79,7 +79,7 @@ describe TrlnArgon::TrlnSearchBuilderBehavior do
       end
     end
 
-    context 'all fields search contains a messy isbn search' do
+    context 'when all fields search contains a messy isbn search' do
       let(:builder_with_params) { search_builder.with(q: '98---121     00822') }
 
       it 'sets the isxn_ns_v parameter' do
@@ -97,7 +97,7 @@ describe TrlnArgon::TrlnSearchBuilderBehavior do
       end
     end
 
-    context 'all fields search with multiple isxn values and random text' do
+    context 'when all fields search with multiple isxn values and random text' do
       let(:builder_with_params) { search_builder.with(q: 'alexander and the terrible 9812100822 03431258') }
 
       it 'sets the isxn_ns_v parameter' do


### PR DESCRIPTION
Adds SyndeticsData object that parses outpuf from Syndetics "xml.xml" query type to determine availability of various data types and transform them, e.g.

`sd.summary?` checks if summary is available
`sd.summary` outputs (HTML) summary (or empty string if not available)

see also:

`sd.samplechapter`
`sd.authornotes`
`sd.avtracklist`
`sd.avreview`
`sd.toc`
`sd.{small,med,lg}cover` # yields URLs to images

Some involve XSLT, all are preliminary.   Includes some mitigation for 'wall of text' data in, e.g. summaries.

Added helper method `enhanced_data(@document)` which yields a SyndeticsData object for use in templates.

