### PR TITLE
Make results (index) page resemble wireframes more closely

### DIFF
--- a/app/assets/javascripts/trln_argon/holdings.js
+++ b/app/assets/javascripts/trln_argon/holdings.js
@@ -1,18 +1,17 @@
 Blacklight.onLoad(function() {
-  Blacklight.do_holdings_display_behavior();
+  // iife to expand the items for a given location if we have been
+  // linked directly to it.
+  (function() {
+    var pageTarget = window.location.hash;
+    if ( pageTarget ) {
+      var locationRe = /^#item-container-/;
+      if ( locationRe.test(pageTarget) ) {
+        $("a[href*='" + pageTarget+ "']").click();
+        $(pageTarget).animate({
+            scrollTop: $(pageTarget).offset().top
+          }, 500);
+      }
+    }
+  })();
 });
 
-(function($) {
-  Blacklight.do_holdings_display_behavior = function() {
-    $("tr.item").hide();
-      // activate  item hide/show click handler
-      $(".loc-narrow-banner").on('click', function() {
-        var container = $(this).closest("tbody");
-        var data = $(this).closest("tr").data();
-        // hides/shows and returns visibility
-        var visible = container.find("tr.item." + data.locbroad + "." + data.locnarrow).toggle().is(":visible");
-        var spander =  visible ? "(- hide items)" : "(+ show items)";
-        $(this).find(".expander").text(spander);
-        });
-  };
-})(jQuery);

--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -105,3 +105,75 @@ panel-success > .panel-heading, .facet_limit-active > .panel-heading {
     font-size: 125%;
     font-weight: bold;
 }
+
+div.items table {
+    width: 100%;
+}
+
+div.items h3 {
+    font-size: 14px;
+    font-weight: bolder;
+}
+
+.input-group {
+    display: table-row;
+}
+
+.input-group-element {
+  display: table-cell;
+  padding: 0 1em;
+  border: none;
+}
+
+.input-group-addon.for-search-field {
+    border-bottom: 0;
+    border-top: 0;   
+}
+
+#search_field {
+    position: relative;
+    top: -.6em;
+}
+
+.input-group-element h3 {
+    padding-top: -5px;
+    margin-top: -5px;
+    vertical-align: top;
+    line-height: 16px;
+  }
+
+.search-extra-controls {
+    clear: left;
+}
+
+#search-navbar .search-query-form {
+    width: 100%;
+}
+
+
+.fulltext-url {
+    border: 2px solid #ddd;
+    border-radius: 2px;
+    padding: 4px;
+    width: 50%;
+}
+
+.expander[aria-expanded=false] .hider {
+    display: none;
+}
+
+.expander[aria-expanded=false] .shower {
+    display: inline;
+}
+
+.expander[aria-expanded=true] .hider {
+    display: inline;
+}
+
+.expander[aria-expanded=true] .shower {
+    display: none;
+}
+
+.item-group {
+    display: none;
+}

--- a/app/views/catalog/_index_items_default.html.erb
+++ b/app/views/catalog/_index_items_default.html.erb
@@ -2,9 +2,7 @@
 <!--       Skip display if holdings are only ONLINE; this is an NCSU-specific hack atm; we might also skip showing print summaries for journals -->
 <% if local_filter_applied? %>
   <% unless ['ONLINE'] == document.holdings.keys %>
-  <%# ||
-            document[TrlnArgon::Fields::FORMAT].include?("Journal/Newspaper")> %>
-    <%= render partial: "items_table", locals: { document: document } %>
+    <%= render partial: "items_table", locals: { document: document, show_items: false } %>
   <% end %>
 <% else %>
   <%= render partial: "availability_table", locals: { expanded_availability: @expanded_documents_hash[document.id] } %>

--- a/app/views/catalog/_items_table.html.erb
+++ b/app/views/catalog/_items_table.html.erb
@@ -1,22 +1,29 @@
-<% unless document.read_items.key?(nil) %>
   <div class="items">
+    <% if document[TrlnArgon::Fields::URL_HREF.to_s] %>
+     <h3>Online</h3>
+      <div class="fulltext-url">
+        <%= url_href_with_url_text_link(value: document[TrlnArgon::Fields::URL_HREF.to_s], document: document) %>
+      </div>
+    <% end %>
+<% unless document.read_items.key?(nil) %>
+    <h3>At the Library</h3>
     <!-- TODO: proper CSS, inline styles MUST NOT STAND -->
-    <table width='100%' class='table table-condensed table-striped table-hover'>
+    <table class='table table-condensed table-striped table-hover'>
       <thead>
         <tr class="holdings-header">
           <th class="location-header">Location</th>
           <th class="callnum-header">Call Number</th>
           <th class="status-header">Status</th>
         </tr>
+      </thead>
       <% document.holdings.each do |loc_b, loc_narrow_map| %>
   <% next if loc_b == 'ONLINE' %>
-  <tbody class="loc-broad-group <% loc_b %>">  
-        <tr class='loc-broad-banner'>
-          <th colspan="3" style='background-color: #ececec; padding: .2em 2em; '><%= map_argon_code(document.record_owner, 'loc_b', loc_b) %>
-        </tr>
+    <tr class='loc-broad-group <%= loc_b %>loc-broad-banner'>
+      <th colspan="3" style='background-color: #ddd; padding: .2em 2em; '><%= map_argon_code(document.record_owner, 'loc_b', loc_b) %>
+    </tr>
   <% loc_narrow_map.each do |loc_n, item_data|  %>
     <tr class="loc-narrow-banner" data-locbroad="<%= loc_b %>"
-    data-locnarrow="<%= loc_n %>">
+    data-locnarrow="<%= loc_n %>" id="<%= "item-details-#{loc_b}-#{loc_n}" %>">
        <% if item_data['summary'] %>
            <th style="width: 20%; padding-left: .5em;">
              <%= map_argon_code(document.record_owner, 'loc_n', loc_n) if loc_n %>
@@ -24,26 +31,42 @@
            <th style="width: 30%;">
     <%= item_data['call_no'] %>
      <th style="width: 50%;">
-              <%= item_data['summary'] %>
-      <span class="expander">(+ show items)</span>
-     </th>
+      <%= item_data['summary'] %>
+      <% if show_items %>
+        <a class="expander" data-toggle='collapse' href='<%= "#item-container-#{loc_b}-#{loc_n}" %>' aria-expanded='false' aria-controls='this'>
+          <span class='shower'>
+            (+ show <%= item_data['items'].length %> items)
+          </span>
+          <span class='hider'>
+            ( - hide all items )
+          </span>
+        </span>
+      <% else %>
+        <span class="item-details-link">
+          <%= link_to "Details", controller: "catalog", action: 'show', id: document.id, anchor: "item-container-#{loc_b}-#{loc_n}" %>
+        </span>
+       <% end %> 
+      </th>
     <% else %>
-           <th colspan="3">
-     <%= map_argon_code(document.record_owner, 'loc_n', loc_n) if loc_n %>
+     <th colspan="3">
+        <%= map_argon_code(document.record_owner, 'loc_n', loc_n) if loc_n %>
      </th>
      <% end %>
     </tr>
-        <% item_data['items'].each do |item| %>
+    <% if show_items %>
+     <tbody class='item-group' id="<%= "item-container-#{loc_b}-#{loc_n}" %>">
+      <% item_data['items'].each do |item| %>
         <tr class="item <%= loc_n %> <%= loc_b %>">
           <td style='width: 20%;'>&nbsp;</td>
           <td style='width: 30%;'><%= item['call_no'] %></td>
           <td style='width: 50%;'><%= item['status'] %></td>
         </tr>
-        <% end %>
       <% end %>
-  </tbody>
+    </tbody>
+    <% end %>
+  <% end %>
         <% end %>
       </tbody>
     </table>
-  </div>
 <% end %>
+</div>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,6 +1,18 @@
 <%= form_tag search_action_url, method: :get, class: 'search-query-form clearfix navbar-form', role: 'search' do %>
+  <% inst = TrlnArgon::Engine.configuration.local_institution_code %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <div class="input-group">
+    <section class="branding">
+      <h1><%= t("trln_argon.institution.#{inst}.long_name") %></h1>
+      <h4>Argonic Catalog</h4>
+    </section>
+
+     <div class='input-group-element'>
+        <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?, data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: blacklight.suggest_index_path }  %>
+      </div>
+
+    <div class="input-group-element">
     <% if search_fields.length > 1 %>
       <span class="input-group-addon for-search-field">
         <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
@@ -9,21 +21,28 @@
     <% elsif search_fields.length == 1 %>
       <%= hidden_field_tag :search_field, search_fields.first.last %>
     <% end %>
+  </div>
 
-    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?, data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: blacklight.suggest_index_path }  %>
-
+  <div class="input-group-element">
     <span class="input-group-btn">
-      <button type="submit" class="btn btn-primary search-btn" id="search">
+        <button type="submit" class="btn btn-primary search-btn" id="search">
         <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
         <span class="glyphicon glyphicon-search"></span>
       </button>
     </span>
   </div>
+</div>
+<div class='search-extra-controls'>
+  <div class='input-group'>
+    <div class='input-group-element'>
+      <label for='search_within'>Search within results</label>
+      <%= check_box :search_within, 'no', disabled: true %>
+    </div>
+    <div class='input-group'>
+      <%= link_to t('blacklight_advanced_search.form.title'), blacklight_advanced_search_engine.advanced_search_path, class: 'advanced_search'%>
+    </div>
+  </div>
+</div>
+
 <% end %>
 
-
-
-<div class="navbar-form">
-  <%= link_to t('blacklight_advanced_search.form.title'), blacklight_advanced_search_engine.advanced_search_path, class: 'advanced_search btn btn-default'%>
-</div>

--- a/app/views/catalog/_show_items_default.html.erb
+++ b/app/views/catalog/_show_items_default.html.erb
@@ -1,9 +1,9 @@
 <h2>Holdings</h2>
 <% if local_filter_applied? %>
-  <%= render partial: "items_table", locals: { document: document } %>
+  <%= render partial: "items_table", locals: { document: document, show_items: true } %>
 <% else %>
   <% document.expanded_documents.each do |doc| %>
   <h3><%= t("trln_argon.institution.#{doc[TrlnArgon::Fields::INSTITUTION].first}.long_name") %></h3>
-    <%= render partial: "items_table", locals: { document: doc } %>
+    <%= render partial: "items_table", locals: { document: doc, show_items: true } %>
   <% end %>
 <% end %>

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -156,9 +156,6 @@ module TrlnArgon
         config.add_index_field TrlnArgon::Fields::INSTITUTION.to_s,
                                label: TrlnArgon::Fields::INSTITUTION.label,
                                helper_method: :institution_code_to_short_name
-        config.add_index_field TrlnArgon::Fields::URL_HREF.to_s,
-                               label: TrlnArgon::Fields::URL_HREF.label,
-                               helper_method: :url_href_with_url_text_link
 
         # solr fields to be displayed in the show (single result) view
         #   The ordering of the field names is the order of the display

--- a/lib/trln_argon/item_deserializer.rb
+++ b/lib/trln_argon/item_deserializer.rb
@@ -28,14 +28,6 @@ module TrlnArgon
             i.reject { |k, _v| %w[loc_b loc_n].include?(k) }
           end
           h['call_no'] = cn_prefix(h['items'])
-          if h['summary'].blank?
-            items = h['items'] || []
-            avail = items.count { |i| 'available' == i['status'].downcase rescue false }
-            sum = "(#{pluralize(items.count, 'copy')}"
-            sum << ", #{avail} available" unless avail == items.count
-            sum << ")"
-            h['summary'] = sum
-          end
           [loc_n, h]
         end]]
       end]

--- a/spec/lib/trln_argon/controller_override_spec.rb
+++ b/spec/lib/trln_argon/controller_override_spec.rb
@@ -129,10 +129,6 @@ describe TrlnArgon::ControllerOverride do
     it 'sets the institution field' do
       expect(override_config.index_fields).to have_key('institution_a')
     end
-
-    it 'sets the URL field' do
-      expect(override_config.index_fields).to have_key('url_href_a')
-    end
   end
 
   describe 'show fields' do


### PR DESCRIPTION
Restyle search form
Remove 'link' from fields shown on results page
Add 'Online' and 'At the Library' sections to holdings display
Use bootstrap 'collapse' for item hide/show
