### PR TITLE
nudge handling closer to desired behavior

### DIFF
--- a/app/views/catalog/_index_items_default.html.erb
+++ b/app/views/catalog/_index_items_default.html.erb
@@ -2,7 +2,7 @@
 <!--       Skip display if holdings are only ONLINE; this is an NCSU-specific hack atm; we might also skip showing print summaries for journals -->
 <% if local_filter_applied? %>
   <% unless ['ONLINE'] == document.holdings.keys %>
-    <%= render partial: "items_table", locals: { document: document, show_items: false } %>
+    <%= render partial: "items_table", locals: { document: document, context: 'index' } %>
   <% end %>
 <% else %>
   <%= render partial: "availability_table", locals: { expanded_availability: @expanded_documents_hash[document.id] } %>

--- a/app/views/catalog/_items_table.html.erb
+++ b/app/views/catalog/_items_table.html.erb
@@ -1,72 +1,16 @@
-  <div class="items">
-    <% if document[TrlnArgon::Fields::URL_HREF.to_s] %>
-     <h3>Online</h3>
-      <div class="fulltext-url">
-        <%= url_href_with_url_text_link(value: document[TrlnArgon::Fields::URL_HREF.to_s], document: document) %>
-      </div>
-    <% end %>
-<% unless document.read_items.key?(nil) %>
+<div class="items">
+  <% if document[TrlnArgon::Fields::URL_HREF.to_s] %>
+    <h3>Online</h3>
+    <div class="fulltext-url">
+      <%= url_href_with_url_text_link(value: document[TrlnArgon::Fields::URL_HREF.to_s], document: document) %>
+    </div>
+  <% end %>
+  <% unless document.read_items.key?(nil) %>
     <h3>At the Library</h3>
-    <!-- TODO: proper CSS, inline styles MUST NOT STAND -->
-    <table class='table table-condensed table-striped table-hover'>
-      <thead>
-        <tr class="holdings-header">
-          <th class="location-header">Location</th>
-          <th class="callnum-header">Call Number</th>
-          <th class="status-header">Status</th>
-        </tr>
-      </thead>
-      <% document.holdings.each do |loc_b, loc_narrow_map| %>
-  <% next if loc_b == 'ONLINE' %>
-    <tr class='loc-broad-group <%= loc_b %>loc-broad-banner'>
-      <th colspan="3" style='background-color: #ddd; padding: .2em 2em; '><%= map_argon_code(document.record_owner, 'loc_b', loc_b) %>
-    </tr>
-  <% loc_narrow_map.each do |loc_n, item_data|  %>
-    <tr class="loc-narrow-banner" data-locbroad="<%= loc_b %>"
-    data-locnarrow="<%= loc_n %>" id="<%= "item-details-#{loc_b}-#{loc_n}" %>">
-       <% if item_data['summary'] %>
-           <th style="width: 20%; padding-left: .5em;">
-             <%= map_argon_code(document.record_owner, 'loc_n', loc_n) if loc_n %>
-           </th>
-           <th style="width: 30%;">
-    <%= item_data['call_no'] %>
-     <th style="width: 50%;">
-      <%= item_data['summary'] %>
-      <% if show_items %>
-        <a class="expander" data-toggle='collapse' href='<%= "#item-container-#{loc_b}-#{loc_n}" %>' aria-expanded='false' aria-controls='this'>
-          <span class='shower'>
-            (+ show <%= item_data['items'].length %> items)
-          </span>
-          <span class='hider'>
-            ( - hide all items )
-          </span>
-        </span>
-      <% else %>
-        <span class="item-details-link">
-          <%= link_to "Details", controller: "catalog", action: 'show', id: document.id, anchor: "item-container-#{loc_b}-#{loc_n}" %>
-        </span>
-       <% end %> 
-      </th>
+    <% if context == 'index' %>
+      <%= render partial: "items_table_index", locals: { document: document} %>
     <% else %>
-     <th colspan="3">
-        <%= map_argon_code(document.record_owner, 'loc_n', loc_n) if loc_n %>
-     </th>
-     <% end %>
-    </tr>
-    <% if show_items %>
-     <tbody class='item-group' id="<%= "item-container-#{loc_b}-#{loc_n}" %>">
-      <% item_data['items'].each do |item| %>
-        <tr class="item <%= loc_n %> <%= loc_b %>">
-          <td style='width: 20%;'>&nbsp;</td>
-          <td style='width: 30%;'><%= item['call_no'] %></td>
-          <td style='width: 50%;'><%= item['status'] %></td>
-        </tr>
-      <% end %>
-    </tbody>
+      <%= render partial: "items_table_show", locals: { document: document } %>
     <% end %>
   <% end %>
-        <% end %>
-      </tbody>
-    </table>
-<% end %>
 </div>

--- a/app/views/catalog/_items_table_index.html.erb
+++ b/app/views/catalog/_items_table_index.html.erb
@@ -1,0 +1,48 @@
+<table class='table table-condensed table-striped table-hover'>
+  <thead>
+    <tr class="holdings-header">
+      <th class="location-header">Location</th>
+      <th class="callnum-header">Call Number</th>
+      <th class="status-header">Status</th>
+    </tr>
+  </thead>
+  <% document.holdings.each do |loc_b, loc_narrow_map| %>
+    <% next if loc_b == 'ONLINE' %>
+    <tr class='loc-broad-group <%= loc_b %>loc-broad-banner'>
+      <th colspan="3" style='background-color: #ddd;'>
+        <%= map_argon_code(document.record_owner, 'loc_b', loc_b) %>
+      </th>
+    </tr>
+  <% loc_narrow_map.each do |loc_n, item_data|  %>
+    <% has_summary =!item_data.fetch('summary', '').blank? %>
+      <% if has_summary %>
+      <tr class='location-narrow-group'>
+        <th style="width: 20%; padding-left: .5em;">
+         <%= map_argon_code(document.record_owner, 'loc_n', loc_n) if loc_n %>
+        </th>
+        <th style="width: 30%;">
+          <%= item_data['call_no'] %>
+        </th>
+        <th class='summary-holdings' style='width: 50%;'>
+          <%= item_data.fetch('summary', '') %>
+          <span class="item-details-link">
+            <%= link_to "Details", controller: "catalog", action: 'show', id: document.id, anchor: "item-container-#{loc_b}-#{loc_n}" %>
+          </span>
+        </th>
+      </tr>
+      <% end %>
+    
+    <% unless has_summary %>
+      <tbody class='item-group-display' id="<%= "item-container-#{loc_b}-#{loc_n}" %>">
+        <% item_data['items'].each do |item| %>
+        <tr class="item <%= loc_n %> <%= loc_b %>">
+          <td style='width: 20%;'><%= map_argon_code(document.record_owner, 'loc_n', loc_n) if loc_n %></td>
+          <td style='width: 30%;'><%= item['call_no'] %></td>
+          <td style='width: 50%;'><%= item['status'] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+    <% end %>
+  <% end %>
+<% end %>
+</table>

--- a/app/views/catalog/_items_table_show.html.erb
+++ b/app/views/catalog/_items_table_show.html.erb
@@ -1,0 +1,54 @@
+<table class='table table-condensed table-striped table-hover'>
+  <thead>
+    <tr class="holdings-header">
+      <th class="location-header">Location</th>
+      <th class="callnum-header">Call Number</th>
+      <th class="status-header">Status</th>
+    </tr>
+  </thead>
+  <% document.holdings.each do |loc_b, loc_narrow_map| %>
+    <% next if loc_b == 'ONLINE' %>
+    <tr class='loc-broad-group <%= loc_b %>loc-broad-banner'>
+      <th colspan="3" style='background-color: #ddd;'>
+        <%= map_argon_code(document.record_owner, 'loc_b', loc_b) %>
+      </th>
+    </tr>
+    <% loc_narrow_map.each do |loc_n, item_data|  %>
+      <% has_summary = !item_data.fetch('summary', 'LOOK MA').blank? %>
+      <% narrow_loc = map_argon_code(document.record_owner, 'loc_n', loc_n) %>
+      <% if has_summary %>
+      <tr class="loc-narrow-banner" data-locbroad="<%= loc_b %>"
+        data-locnarrow="<%= loc_n %>" id="<%= "item-details-#{loc_b}-#{loc_n}" %>">
+        <th style="width: 20%;"">
+          <%= narrow_loc %>
+        </th>
+        <th style="width: 30%;">
+          <%= item_data['call_no'] %>
+        </th>
+        <th style="width: 50%;">
+          <%= item_data['summary'] %>
+          <a class="expander" data-toggle='collapse' href='<%= "#item-container-#{loc_b}-#{loc_n}" %>' aria-expanded='false' aria-controls='this'>
+            <span class='shower'>
+              (+ show <%= item_data['items'].length %> items)
+            </span>
+            <span class='hider'>
+              (- hide all items)
+            </span>
+          </a>
+        </th>
+      </tr>
+      <% end %>
+      
+      <tbody class="item-group<%= has_summary ? '' : '-display' %>" id="<%= "item-container-#{loc_b}-#{loc_n}" %>">
+        <% item_data['items'].each_with_index do |item, index| %>
+          <tr class="item <%= loc_n %> <%= loc_b %>">
+            <td style='width: 30%;'><%= index == 0 ? "\u2937" : "\u00a0\u00a0\u00a0" %><%= narrow_loc %></td>
+            <td style='width: 30%;'><%= item['call_no'] %></td>
+            <td style='width: 40%;'><%= item['status'] %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      <% end %>
+    <% end %>
+</table>
+    

--- a/app/views/catalog/_show_items_default.html.erb
+++ b/app/views/catalog/_show_items_default.html.erb
@@ -1,9 +1,9 @@
 <h2>Holdings</h2>
 <% if local_filter_applied? %>
-  <%= render partial: "items_table", locals: { document: document, show_items: true } %>
+  <%= render partial: "items_table", locals: { document: document, context: 'show' } %>
 <% else %>
   <% document.expanded_documents.each do |doc| %>
   <h3><%= t("trln_argon.institution.#{doc[TrlnArgon::Fields::INSTITUTION].first}.long_name") %></h3>
-    <%= render partial: "items_table", locals: { document: doc, show_items: true } %>
+    <%= render partial: "items_table", locals: { document: doc, context: 'show' } %>
   <% end %>
 <% end %>

--- a/lib/trln_argon/item_deserializer.rb
+++ b/lib/trln_argon/item_deserializer.rb
@@ -27,6 +27,7 @@ module TrlnArgon
           h['items'] = loc_items.map do |i|
             i.reject { |k, _v| %w[loc_b loc_n].include?(k) }
           end
+          h['summary'] ||= ''
           h['call_no'] = cn_prefix(h['items'])
           [loc_n, h]
         end]]


### PR DESCRIPTION
Move handling of index (brief) and show (full) items/holdings display into separate files.
brief: show summary (w/link to details) by itself when it is available, otherwise show items.
full: show summary with link to expand holdings when it is available, otherwise show items.
Some formatting changes.