### PR TITLE
First pass at making show record page resemble wireframes.

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -101,11 +101,6 @@ panel-success > .panel-heading, .facet_limit-active > .panel-heading {
     flex-basis: auto;
 }
 
-.enhanced-data section  header {
-    font-size: 125%;
-    font-weight: bold;
-}
-
 div.items table {
     width: 100%;
 }
@@ -187,12 +182,26 @@ div.items h3 {
 
 .enhanced-data section .show-control {
     display: none;
+    font-size: 14px;
 }
 
 .enhanced-data section[aria-expanded=false] .show-control.more {
-    display: inline;    
+    display: inline;
 }
 
 .enhanced-data section[aria-expanded=true] .show-control.less {
     display: inline;
+}
+
+.show-document {
+    ul {
+        list-style-type: none;
+        padding-left: 0;
+    }
+}
+
+#show-sub-header {
+    li {
+        font-size: 18px;
+    }
 }

--- a/app/views/catalog/_items_table_show.html.erb
+++ b/app/views/catalog/_items_table_show.html.erb
@@ -19,8 +19,8 @@
       <% if has_summary %>
       <tr class="loc-narrow-banner" data-locbroad="<%= loc_b %>"
         data-locnarrow="<%= loc_n %>" id="<%= "item-details-#{loc_b}-#{loc_n}" %>">
-        <th style="width: 20%;"">
-          <%= narrow_loc %>
+        <th style="width: 20%;">
+          <%= narrow_loc if loc_n %>
         </th>
         <th style="width: 30%;">
           <%= item_data['call_no'] %>
@@ -42,7 +42,7 @@
       <tbody class="item-group<%= has_summary ? '' : '-display' %>" id="<%= "item-container-#{loc_b}-#{loc_n}" %>">
         <% item_data['items'].each_with_index do |item, index| %>
           <tr class="item <%= loc_n %> <%= loc_b %>">
-            <td style='width: 30%;'><%= index == 0 ? "\u2937" : "\u00a0\u00a0\u00a0" %><%= narrow_loc %></td>
+            <td style='width: 30%;'><%= index == 0 ? "\u2937" : "\u00a0\u00a0\u00a0" %><%= narrow_loc if loc_n %></td>
             <td style='width: 30%;'><%= item['call_no'] %></td>
             <td style='width: 40%;'><%= item['status'] %></td>
           </tr>

--- a/app/views/catalog/_show_authors_default.html.erb
+++ b/app/views/catalog/_show_authors_default.html.erb
@@ -1,0 +1,12 @@
+<% display_values = show_configured_fields_and_values(blacklight_config.show_authors_fields, document) %>
+<div class="show-authors">
+  <% if display_values.any? %>
+    <h2><%= t('trln_argon.show.heading.authors') %></h2>
+    <dl class="dl-horizontal  dl-invert">
+      <% display_values.each do |value| %>
+          <dt class="blacklight-<%= value[:field].parameterize %>"><%= "#{value[:label]}:" %></dt>
+          <dd class="blacklight-<%= value[:field].parameterize %>"><%= value[:value] %></dd>
+      <% end -%>
+    </dl>
+  <% end %>
+</div>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,0 +1,15 @@
+<%# default partial to display solr document fields in catalog show view -%>
+<% display_values = show_configured_fields_and_values(blacklight_config.show_fields, document) %>
+<% if display_values.any? %>
+  <div class="other-details">
+    <h2><%= t('trln_argon.show.heading.metadata') %></h2>
+    <dl class="dl-horizontal  dl-invert">
+      <% document_show_fields(document).each do |field_name, field| -%>
+        <% if should_render_show_field? document, field %>
+          <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
+          <dd class="blacklight-<%= field_name.parameterize %>"><%= presenter(document).field_value(field) %></dd>
+        <% end -%>
+      <% end -%>
+    </dl>
+  </div>
+<% end %>

--- a/app/views/catalog/_show_document_tools.html.erb
+++ b/app/views/catalog/_show_document_tools.html.erb
@@ -1,0 +1,9 @@
+<!-- TODO: These will need wiring up. At the moment, they do nothing. -->
+<div id="document-tools" class="btn-group" role="group" aria-label="...">
+  <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-plane" aria-hidden="true"></span>&nbsp;Request</button>
+  <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-phone" aria-hidden="true"></span>&nbsp;Text</button>
+  <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>&nbsp;Email</button>
+  <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-print" aria-hidden="true"></span>&nbsp;Print</button>
+  <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-export" aria-hidden="true"></span>&nbsp;Export to Refworks</button>
+  <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>&nbsp;Get Help</button>
+</div>

--- a/app/views/catalog/_show_items_default.html.erb
+++ b/app/views/catalog/_show_items_default.html.erb
@@ -1,4 +1,4 @@
-<h2>Holdings</h2>
+<h2><%= t('trln_argon.show.heading.holdings') %></h2>
 <% if local_filter_applied? %>
   <%= render partial: "items_table", locals: { document: document, context: 'show' } %>
 <% else %>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,0 +1,36 @@
+<%= render 'previous_next_doc' %>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= render partial: 'show_document_tools' %>
+  </div>
+</div>
+
+<% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
+<% content_for(:head) { render_link_rel_alternates } %>
+
+<div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
+  <div id="doc_<%= @document.id.to_s.parameterize %>">
+    <div class="col-md-12">
+      <%= render_document_partials @document, blacklight_config.view_config(:show).heading_partials %>
+    </div>
+    <div class="col-md-10 offset-md-2">
+      <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+      <div class="librarian-tools">
+        <!-- TODO: Placeholder based on wireframes. Not functional yet.
+                   Should probably create a partial for this and wire it through
+                   the blacklight partials config. -->
+        <p><a href="#">View MARC record for this title</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
+  <!-- 
+       // COinS, for Zotero among others. 
+       // This document_partial_name(@document) business is not quite right,
+       // but has been there for a while. 
+  -->
+  <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
+<% end %>

--- a/app/views/catalog/_show_sub_header_default.html.erb
+++ b/app/views/catalog/_show_sub_header_default.html.erb
@@ -1,0 +1,12 @@
+<% display_values = show_configured_fields_and_values(blacklight_config.show_sub_header_fields, document) %>
+<div id="show-sub-header">
+  <% if display_values.any? %>
+    <ul>
+    <% display_values.each do |values| %>
+      <li class="sub-header <%= values[:field]  %>">
+        <%= values[:value] %>
+      </li>
+    <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/catalog/_show_subjects_default.html.erb
+++ b/app/views/catalog/_show_subjects_default.html.erb
@@ -1,0 +1,11 @@
+<% display_values = show_configured_fields_and_values(blacklight_config.show_subjects_fields, document) %>
+<div class="show-subjects">
+  <% if display_values.any? %>
+    <h2><%= t('trln_argon.show.heading.subjects') %></h2>
+    <ul>
+      <% display_values.each do |value| %>
+          <%= value[:value] %>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/catalog/_show_summary_default.html.erb
+++ b/app/views/catalog/_show_summary_default.html.erb
@@ -5,8 +5,9 @@
   <% samplechapter = ( s && s.samplechapter? && s.samplechapter ) || nil %>
   <% unless summary.nil? || summary.empty? %>
     <section class="summary">
-      <h4>Summary <span class='show-control more'><a href="javascript:void(0);">(show more)</a></span>
-      <span class='show-control less'><a href="javascript:void(0);">(show less)</a></span></h4>
+
+      <h2>Summary <span class='show-control more'><a href="javascript:void(0);">(show more)</a></span>
+      <span class='show-control less'><a href="javascript:void(0);">(show less)</a></span></h2>
       
       <div class="content">
         <%= summary.html_safe %>
@@ -16,8 +17,8 @@
   <% end %>
   <% unless toc.nil? || toc.empty? %>
     <section class="table-of-contents">
-  	  <h4>Contents <span class='show-control more'><a href="javascript:void(0);">(show more)</a></span>
-      <span class='show-control less'><a href="javascript:void(0);">(show less)</a></span></h4>
+  	  <h2>Contents <span class='show-control more'><a href="javascript:void(0);">(show more)</a></span>
+      <span class='show-control less'><a href="javascript:void(0);">(show less)</a></span></h2>
       
       <div class="content">
   	   <%= toc.html_safe %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,0 +1,3 @@
+<div id="content" class="col-md-12 show-document">
+  <%= render_document_main_content_partial %>
+</div>

--- a/config/initializers/blacklight_configuration.rb
+++ b/config/initializers/blacklight_configuration.rb
@@ -1,0 +1,9 @@
+# Add some configurable field sets to Blacklight's Configuration class
+# See configurations in lib/trln_argon/controller_override.rb
+module Blacklight
+  class Configuration
+    define_field_access :show_sub_header_field
+    define_field_access :show_authors_field
+    define_field_access :show_subjects_field
+  end
+end

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -86,3 +86,12 @@ en:
         search_constraints:
             begins_with: "begins with"
             location_separator: ", "
+
+        show:
+            heading:
+                holdings: "Where to find it"
+                authors: "Authors, etc."
+                summary: "Summary"
+                contents: "Contents"
+                subjects: "This item is about"
+                metadata: "Other details"

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -32,7 +32,12 @@ module TrlnArgon
         config.document_solr_path = :document
         config.document_solr_request_handler = nil
 
-        config.show.partials = %i[show_header show_thumbnail show show_summary show_items]
+        config.show.heading_partials = %i[show_thumbnail show_header show_sub_header]
+        config.show.partials = %i[show_items
+                                  show_authors
+                                  show_summary
+                                  show_subjects
+                                  show]
 
         # Set partials to render
         config.index.partials = %i[index_header thumbnail index index_items]
@@ -118,6 +123,9 @@ module TrlnArgon
                                },
                                label: TrlnArgon::Fields::DATE_CATALOGED_FACET.label,
                                limit: true
+        config.add_facet_field TrlnArgon::Fields::AUTHORS_MAIN_FACET.to_s,
+                               label: TrlnArgon::Fields::AUTHORS_MAIN_FACET.label,
+                               show: false
 
         # Subject is configured as a facet and set not to display so that the field
         # label will be accessible for the begins_with filter. Set other fields that will
@@ -159,29 +167,43 @@ module TrlnArgon
 
         # solr fields to be displayed in the show (single result) view
         #   The ordering of the field names is the order of the display
-        config.add_show_field TrlnArgon::Fields::TITLE_MAIN.to_s,
-                              label: TrlnArgon::Fields::TITLE_MAIN.label
-        config.add_show_field TrlnArgon::Fields::AUTHORS_MAIN.to_s,
-                              label: TrlnArgon::Fields::AUTHORS_MAIN.label
-        config.add_show_field TrlnArgon::Fields::FORMAT.to_s,
-                              label: TrlnArgon::Fields::FORMAT.label
-        config.add_show_field TrlnArgon::Fields::LANGUAGE.to_s,
-                              label: TrlnArgon::Fields::LANGUAGE.label
-        config.add_show_field TrlnArgon::Fields::SUBJECTS.to_s,
-                              label: TrlnArgon::Fields::SUBJECTS.label,
-                              helper_method: :link_to_subject_segments
-        config.add_show_field TrlnArgon::Fields::PUBLISHER_ETC.to_s,
-                              label: TrlnArgon::Fields::PUBLISHER_ETC.label
+        config.add_show_field TrlnArgon::Fields::TITLE_UNIFORM.to_s,
+                              label: TrlnArgon::Fields::TITLE_UNIFORM.label
+        config.add_show_field TrlnArgon::Fields::FREQUENCY_CURRENT.to_s,
+                              label: TrlnArgon::Fields::FREQUENCY_CURRENT.label
+        config.add_show_field TrlnArgon::Fields::DESCRIPTION_GENERAL.to_s,
+                              label: TrlnArgon::Fields::DESCRIPTION_GENERAL.label
+        config.add_show_field TrlnArgon::Fields::DESCRIPTION_VOLUMES.to_s,
+                              label: TrlnArgon::Fields::DESCRIPTION_VOLUMES.label
+        config.add_show_field TrlnArgon::Fields::NOTES_INDEXED.to_s,
+                              label: TrlnArgon::Fields::NOTES_INDEXED.label
+        config.add_show_field TrlnArgon::Fields::LINKING_HAS_SUPPLEMENT.to_s,
+                              label: TrlnArgon::Fields::LINKING_HAS_SUPPLEMENT.label
         config.add_show_field TrlnArgon::Fields::ISBN_NUMBER.to_s,
                               label: TrlnArgon::Fields::ISBN_NUMBER.label
-        config.add_show_field TrlnArgon::Fields::PUBLICATION_YEAR_SORT.to_s,
-                              label: TrlnArgon::Fields::PUBLICATION_YEAR_SORT.label
-        config.add_show_field TrlnArgon::Fields::INSTITUTION.to_s,
-                              label: TrlnArgon::Fields::INSTITUTION.label,
-                              helper_method: :institution_code_to_short_name
-        config.add_show_field TrlnArgon::Fields::URL_HREF.to_s,
-                              label: TrlnArgon::Fields::URL_HREF.label,
-                              helper_method: :url_href_with_url_text_link
+        config.add_show_field TrlnArgon::Fields::ISSN_LINKING.to_s,
+                              label: TrlnArgon::Fields::ISSN_LINKING.label
+        config.add_show_field TrlnArgon::Fields::OCLC_NUMBER.to_s,
+                              label: TrlnArgon::Fields::OCLC_NUMBER.label
+
+        config.add_show_sub_header_field TrlnArgon::Fields::AUTHORS_MAIN.to_s
+        config.add_show_sub_header_field TrlnArgon::Fields::IMPRINT.to_s
+        config.add_show_sub_header_field TrlnArgon::Fields::FORMAT.to_s
+
+        # NOTE: What field should be searched when linking to a search for various
+        #       author/contributer fields from the record show page? The "Author" facet
+        #       combines these into a single field and may exclude values that are displayed.
+        #       For now, linking to the same field that is displayed.
+        config.add_show_authors_field TrlnArgon::Fields::AUTHORS_MAIN.to_s,
+                                      label: TrlnArgon::Fields::AUTHORS_MAIN.label,
+                                      link_to_search: TrlnArgon::Fields::AUTHORS_MAIN_FACET.to_s
+        config.add_show_authors_field TrlnArgon::Fields::AUTHORS_DIRECTOR.to_s,
+                                      label: TrlnArgon::Fields::AUTHORS_DIRECTOR.label
+        config.add_show_authors_field TrlnArgon::Fields::AUTHORS_OTHER.to_s,
+                                      label: TrlnArgon::Fields::AUTHORS_OTHER.label
+
+        config.add_show_subjects_field TrlnArgon::Fields::SUBJECTS.to_s,
+                                       helper_method: :list_of_linked_subjects_segments
 
         # "fielded" search configuration. Used by pulldown among other places.
         # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/lib/trln_argon/helpers/render_constraints_helper_behavior.rb
+++ b/lib/trln_argon/helpers/render_constraints_helper_behavior.rb
@@ -17,7 +17,7 @@ module TrlnArgon
     # @param [Array<String>] selected facet values
     # @param [Hash] query parameters
     # @return [String]
-    def render_filter_element(facet, values, localized_params)
+    def render_filter_element(facet, values, _localized_params)
       facet_config = facet_configuration_for_field(facet)
 
       safe_join(values.map do |val|
@@ -25,7 +25,7 @@ module TrlnArgon
         display_value = filter_element_display_value(facet_config, facet, val)
         render_constraint_element(
           facet_field_label(facet_config.key), display_value,
-          remove: search_action_path(remove_facet_params(facet, val, localized_params)),
+          remove: search_action_path(search_state.remove_facet_params(facet, val)),
           classes: ['filter', 'filter-' + facet.parameterize]
         )
       end, "\n")

--- a/lib/trln_argon/helpers/trln_argon_helper_behavior.rb
+++ b/lib/trln_argon/helpers/trln_argon_helper_behavior.rb
@@ -58,8 +58,14 @@ module TrlnArgon
       TrlnArgon::LookupManager.instance.map([inst, context, value].join('.'))
     end
 
+    def list_of_linked_subjects_segments(options = {})
+      link_to_subject_segments(options).map do |subject|
+        content_tag(:li, subject, class: options[:field])
+      end.join('').html_safe
+    end
+
     def link_to_subject_segments(options = {})
-      options[:value].map { |subject| build_segment_links(subject) }.join('<br />').html_safe
+      options[:value].map { |subject| build_segment_links(subject).html_safe }
     end
 
     def location_filter_display(value = '')
@@ -68,6 +74,15 @@ module TrlnArgon
       values.map do |code|
         map_argon_code(values.first, 'facet', code)
       end.join(I18n.t('trln_argon.search_constraints.location_separator'))
+    end
+
+    def show_configured_fields_and_values(config, document)
+      config.map do |field_name, field|
+        next unless document_has_value?(document, field)
+        { field: field_name,
+          label: field.label,
+          value: presenter(document).field_value(field) }
+      end.compact
     end
 
     private

--- a/lib/trln_argon/solr_field_defaults.yml
+++ b/lib/trln_argon/solr_field_defaults.yml
@@ -9,7 +9,7 @@ AUTHOR_FACET:
 AUTHORS_DIRECTOR:
   solr_field: :authors_director_a
   label:
-    en: Authors Director
+    en: Director
 AUTHORS_DIRECTOR_MARC_SOURCE:
   solr_field: :authors_director_marc_source_a
   label:
@@ -25,7 +25,7 @@ AUTHORS_MAIN_CJK_V:
 AUTHORS_MAIN_FACET:
   solr_field: :authors_main_f
   label:
-    en: Author
+    en: Main Author
 AUTHORS_MAIN_MARC_SOURCE:
   solr_field: :authors_main_marc_source_a
   label:
@@ -49,7 +49,7 @@ AUTHORS_MAIN_VERNACULAR_LANG:
 AUTHORS_OTHER:
   solr_field: :authors_other_a
   label:
-    en: Authors Other
+    en: Other Authors
 AUTHORS_OTHER_CJK_V:
   solr_field: :authors_other_cjk_v
   label:
@@ -165,7 +165,7 @@ DESCRIPTION_DIGITAL_FILE_T:
 DESCRIPTION_GENERAL:
   solr_field: :description_general_a
   label:
-    en: Description General
+    en: Physical Description
 DESCRIPTION_GENERAL_T:
   solr_field: :description_general_t
   label:
@@ -201,7 +201,7 @@ DESCRIPTION_VIDEO_T:
 DESCRIPTION_VOLUMES:
   solr_field: :description_volumes_a
   label:
-    en: Description Volumes
+    en: Volume/Date Range
 DISTRIBUTION_STATEMENT:
   solr_field: :distribution_statement_a
   label:
@@ -241,7 +241,7 @@ FORMAT_FACET:
 FREQUENCY_CURRENT:
   solr_field: :frequency_current_a
   label:
-    en: Frequency Current
+    en: Frequency
 FREQUENCY_FORMER:
   solr_field: :frequency_former_a
   label:
@@ -289,11 +289,11 @@ ISBN:
 ISBN_NUMBER:
   solr_field: :isbn_number_a
   label:
-    en: ISBN Number
+    en: ISBN
 ISBN_NUMBER_ISBN:
   solr_field: :isbn_number_isbn
   label:
-    en: ISBN Number
+    en: ISBN
 ISBN_QUALIFYING_INFO:
   solr_field: :isbn_qualifying_info_a
   label:
@@ -309,7 +309,7 @@ ISSN:
 ISSN_LINKING:
   solr_field: :issn_linking_a
   label:
-    en: ISSN Linking
+    en: ISSN
 ISSN_LINKING_ISBN:
   solr_field: :issn_linking_isbn
   label:
@@ -469,7 +469,7 @@ LINKING_ADDED_ENTRY_T:
 LINKING_HAS_SUPPLEMENT:
   solr_field: :linking_has_supplement_a
   label:
-    en: Linking Has Supplement
+    en: Has Supplement
 LINKING_HAS_SUPPLEMENT_ISN:
   solr_field: :linking_has_supplement_isn_a
   label:
@@ -609,7 +609,7 @@ NOTES_ADDITIONAL_VERNACULAR_LANG:
 NOTES_INDEXED:
   solr_field: :notes_indexed_a
   label:
-    en: Notes Indexed
+    en: Notes
 NOTES_INDEXED_CJK_V:
   solr_field: :notes_indexed_cjk_v
   label:
@@ -641,7 +641,7 @@ NOTES_SERIALS_SUMMARY_T:
 OCLC_NUMBER:
   solr_field: :oclc_number
   label:
-    en: Oclc Number
+    en: OCLC Number
 OCLC_NUMBER_OLD:
   solr_field: :oclc_number_old_a
   label:
@@ -953,7 +953,7 @@ TITLE_TRANSLATION_T:
 TITLE_UNIFORM:
   solr_field: :title_uniform_a
   label:
-    en: Title Uniform
+    en: Uniform Title
 TITLE_UNIFORM_T:
   solr_field: :title_uniform_t
   label:

--- a/spec/features/full_records_spec.rb
+++ b/spec/features/full_records_spec.rb
@@ -2,14 +2,6 @@ describe 'full records' do
   context 'when it displays multiple fields from the record' do
     before { visit solr_document_path(id: 'DUKE002960043') }
 
-    it 'displays the title field label' do
-      expect(page).to have_css('dt.blacklight-title_main', text: 'Title:')
-    end
-
-    it 'displays the title field value' do
-      expect(page).to have_css('dd.blacklight-title_main', text: /.+/)
-    end
-
     it 'displays the author field label' do
       expect(page).to have_css('dt.blacklight-authors_main_a', text: 'Author:')
     end
@@ -18,44 +10,28 @@ describe 'full records' do
       expect(page).to have_css('dd.blacklight-authors_main_a', text: /.+/)
     end
 
-    it 'displays the format field label' do
-      expect(page).to have_css('dt.blacklight-format_a', text: 'Format:')
+    it 'displays the physical description field label' do
+      expect(page).to have_css('dt.blacklight-description_general_a', text: 'Physical Description:')
     end
 
-    it 'displays the format field value' do
-      expect(page).to have_css('dd.blacklight-format_a', text: /.+/)
+    it 'displays the physical description field value' do
+      expect(page).to have_css('dd.blacklight-description_general_a', text: /.+/)
     end
 
-    it 'displays the language field label' do
-      expect(page).to have_css('dt.blacklight-language_a', text: 'Language:')
+    it 'displays the notes field label' do
+      expect(page).to have_css('dt.blacklight-notes_indexed_a', text: 'Notes:')
     end
 
-    it 'displays the language field value' do
-      expect(page).to have_css('dd.blacklight-language_a', text: /.+/)
+    it 'displays the notes field value' do
+      expect(page).to have_css('dd.blacklight-notes_indexed_a', text: /.+/)
     end
 
-    it 'displays the subjects field label' do
-      expect(page).to have_css('dt.blacklight-subjects_a', text: 'Subjects:')
+    it 'displays the ISBN field label' do
+      expect(page).to have_css('dt.blacklight-isbn_number_a', text: 'ISBN:')
     end
 
-    it 'displays the subjects field value' do
-      expect(page).to have_css('dd.blacklight-subjects_a', text: /.+/)
-    end
-
-    it 'displays the publication date field label' do
-      expect(page).to have_css('dt.blacklight-publication_year_isort_stored_single', text: 'Publication Year:')
-    end
-
-    it 'displays the publication date field value' do
-      expect(page).to have_css('dd.blacklight-publication_year_isort_stored_single', text: /.+/)
-    end
-
-    it 'displays the institution field label' do
-      expect(page).to have_css('dt.blacklight-institution_a', text: 'Institution:')
-    end
-
-    it 'displays the institution field value' do
-      expect(page).to have_css('dd.blacklight-institution_a', text: /.+/)
+    it 'displays the ISBN field value' do
+      expect(page).to have_css('dd.blacklight-isbn_number_a', text: /.+/)
     end
   end
 end

--- a/spec/helpers/trln_argon_helper_spec.rb
+++ b/spec/helpers/trln_argon_helper_spec.rb
@@ -238,10 +238,10 @@ describe TrlnArgonHelper do
         allow(context).to receive(:local_filter_applied?).and_return(false)
         allow(context).to receive(:search_action_url).and_return('/catalog?begins_with=something')
         expect(context.helpers.link_to_subject_segments(options)).to(
-          eq('<a href="/catalog?begins_with=something">Technology</a> -- '\
-             '<a href="/catalog?begins_with=something">History</a> -- '\
-             '<a href="/catalog?begins_with=something">Science</a><br />'\
-             '<a href="/catalog?begins_with=something">Galilei, Galileo, 1564-1642</a>')
+          eq(['<a href="/catalog?begins_with=something">Technology</a> -- '\
+              '<a href="/catalog?begins_with=something">History</a> -- '\
+              '<a href="/catalog?begins_with=something">Science</a>',
+              '<a href="/catalog?begins_with=something">Galilei, Galileo, 1564-1642</a>'])
         )
       end
     end

--- a/spec/lib/trln_argon/controller_override_spec.rb
+++ b/spec/lib/trln_argon/controller_override_spec.rb
@@ -132,44 +132,36 @@ describe TrlnArgon::ControllerOverride do
   end
 
   describe 'show fields' do
-    it 'sets the title main field' do
-      expect(override_config.show_fields).to have_key('title_main')
+    it 'sets the Uniform Title field' do
+      expect(override_config.show_fields).to have_key('title_uniform_a')
     end
 
-    it 'sets the authors main field' do
-      expect(override_config.show_fields).to have_key('authors_main_a')
+    it 'sets the Current Frequency field' do
+      expect(override_config.show_fields).to have_key('frequency_current_a')
     end
 
-    it 'sets the format field' do
-      expect(override_config.show_fields).to have_key('format_a')
+    it 'sets the General Description field' do
+      expect(override_config.show_fields).to have_key('description_general_a')
     end
 
-    it 'sets the title language field' do
-      expect(override_config.show_fields).to have_key('language_a')
+    it 'sets the Volume Description field' do
+      expect(override_config.show_fields).to have_key('description_volumes_a')
     end
 
-    it 'sets the subjects field' do
-      expect(override_config.show_fields).to have_key('subjects_a')
-    end
-
-    it 'sets the publisher field' do
-      expect(override_config.show_fields).to have_key('publisher_etc_a')
+    it 'sets the Notes field' do
+      expect(override_config.show_fields).to have_key('notes_indexed_a')
     end
 
     it 'sets the ISBN field' do
       expect(override_config.show_fields).to have_key('isbn_number_a')
     end
 
-    it 'sets the publication year field' do
-      expect(override_config.show_fields).to have_key('publication_year_isort_stored_single')
+    it 'sets the ISSN field' do
+      expect(override_config.show_fields).to have_key('issn_linking_a')
     end
 
-    it 'sets the institution field' do
-      expect(override_config.show_fields).to have_key('institution_a')
-    end
-
-    it 'sets the URL field' do
-      expect(override_config.show_fields).to have_key('url_href_a')
+    it 'sets the OCLC Number field' do
+      expect(override_config.show_fields).to have_key('oclc_number')
     end
   end
 


### PR DESCRIPTION
As proof-of-concept I added some new configurable field sets to Blacklight's Configuration class. This lets us use the standard Blacklight way of defining field sets in a configure block (e.g. `add_show_field`, etc.) for the additional sections present in the wireframes.

I think this is a convenient way of allowing local customization of the fields that show up in the different show page sections. For example, to add fields that should show up under "Authors, etc." you just add something like this to a Blacklight configure block:

```
        config.add_show_authors_field TrlnArgon::Fields::AUTHORS_MAIN.to_s,
                                      label: TrlnArgon::Fields::AUTHORS_MAIN.label,
                                      link_to_search: TrlnArgon::Fields::AUTHORS_MAIN_FACET.to_s
        config.add_show_authors_field TrlnArgon::Fields::AUTHORS_DIRECTOR.to_s,
                                      label: TrlnArgon::Fields::AUTHORS_DIRECTOR.label
        config.add_show_authors_field TrlnArgon::Fields::AUTHORS_OTHER.to_s,
                                      label: TrlnArgon::Fields::AUTHORS_OTHER.label
```