### PR TITLE
Modify Argon to use serialized url field data.

### DIFF
--- a/app/views/catalog/_availability_table.html.erb
+++ b/app/views/catalog/_availability_table.html.erb
@@ -2,13 +2,21 @@
   <table  width='100%' class='table table-condensed'>
     <caption>Location</caption>
     <tbody>
-      <% expanded_availability.each do |institution, values| %>
+      <% expanded_availability.each do |institution, doc| %>
         <tr>
           <td><%= t("trln_argon.institution.#{institution}.long_name") %></td>
-          <td><%= values[:availability] %></td>
-          <% if values[:url].present? %>
-            <% short_name = t("trln_argon.institution.#{institution}.short_name") %>
-            <td><%= link_to "Online Access (#{short_name} Only)", values[:url].first %></td>
+          <td><%= doc.availability %></td>
+          <% if doc.fulltext_urls.any? || doc.findingaid_urls.any? %>
+            <td>
+              <ul>
+              <% doc.fulltext_urls.each do |url| %>
+                <li><%= link_to_primary_url(url) %></li>
+              <% end %>
+              <% doc.findingaid_urls.each do |url| %>
+                <li><%= link_to_primary_url(url) %></li>
+              <% end %>
+              </ul>
+            </td>
           <% else %>
             <td></td>
           <% end %>

--- a/app/views/catalog/_items_table.html.erb
+++ b/app/views/catalog/_items_table.html.erb
@@ -1,8 +1,15 @@
 <div class="items">
-  <% if document[TrlnArgon::Fields::URL_HREF.to_s] %>
+  <% if document.fulltext_urls.any? || document.findingaid_urls.any? %>
     <h3>Online</h3>
     <div class="fulltext-url">
-      <%= url_href_with_url_text_link(value: document[TrlnArgon::Fields::URL_HREF.to_s], document: document) %>
+      <ul>
+      <% document.fulltext_urls.each do |url| %>
+        <li><%= link_to_primary_url(url) %></li>
+      <% end %>
+      <% document.findingaid_urls.each do |url| %>
+        <li><%= link_to_primary_url(url) %></li>
+      <% end %>
+      </ul>
     </div>
   <% end %>
   <% unless document.read_items.key?(nil) %>

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -175,6 +175,10 @@ module TrlnArgon
                               label: TrlnArgon::Fields::NOTES_INDEXED.label
         config.add_show_field TrlnArgon::Fields::LINKING_HAS_SUPPLEMENT.to_s,
                               label: TrlnArgon::Fields::LINKING_HAS_SUPPLEMENT.label
+        config.add_show_field TrlnArgon::Fields::SECONDARY_URLS.to_s,
+                              label: TrlnArgon::Fields::SECONDARY_URLS.label,
+                              accessor: :secondary_urls,
+                              helper_method: :link_to_secondary_urls
         config.add_show_field TrlnArgon::Fields::ISBN_NUMBER.to_s,
                               label: TrlnArgon::Fields::ISBN_NUMBER.label
         config.add_show_field TrlnArgon::Fields::ISSN_LINKING.to_s,
@@ -326,9 +330,7 @@ module TrlnArgon
         end.first
         group_docs = group_docs.respond_to?(:docs) ? group_docs.docs : [doc]
         Hash[group_docs.map do |gr_doc|
-          [gr_doc[TrlnArgon::Fields::INSTITUTION].first,
-           { availability: gr_doc.availability,
-             url: gr_doc[TrlnArgon::Fields::URL_HREF] }]
+          [gr_doc[TrlnArgon::Fields::INSTITUTION].first, gr_doc]
         end]
       end
 
@@ -351,7 +353,7 @@ module TrlnArgon
                                              'group.limit' => '4',
                                              fl: "#{TrlnArgon::Fields::ID}, #{TrlnArgon::Fields::ROLLUP_ID}, "\
                                                  "#{TrlnArgon::Fields::INSTITUTION}, #{TrlnArgon::Fields::AVAILABLE}, "\
-                                                 "#{TrlnArgon::Fields::URL_HREF}")
+                                                 "#{TrlnArgon::Fields::URLS}")
       end
 
       def expanded_documents_response

--- a/lib/trln_argon/helpers/blacklight_helper_behavior.rb
+++ b/lib/trln_argon/helpers/blacklight_helper_behavior.rb
@@ -6,5 +6,16 @@ module TrlnArgon
     def application_name
       TrlnArgon::Engine.configuration.application_name
     end
+
+    # Fixes a bug in blacklight. In the case where an accessor method is
+    # used to retrieve the field value this method needs to check for the presence
+    # of a value returned from that accessor method, not merely the presence of an accessor method
+    # or a field value. This prevents a field label from being output if there's no value
+    # returned by the accessor method.
+    def document_has_value?(document, field_config)
+      document.has?(field_config.field) ||
+        (document.has_highlight_field? field_config.field if field_config.highlight) ||
+        (field_config.accessor && document.send(field_config.accessor).present?)
+    end
   end
 end

--- a/lib/trln_argon/helpers/trln_argon_helper_behavior.rb
+++ b/lib/trln_argon/helpers/trln_argon_helper_behavior.rb
@@ -46,14 +46,6 @@ module TrlnArgon
       end
     end
 
-    def url_href_with_url_text_link(options = {})
-      text = online_access_link_text(options[:value], options[:document][TrlnArgon::Fields::URL_TEXT])
-      hrefs_and_text = options[:value].zip(text)
-      hrefs_and_text.map do |href_text_pair|
-        link_to href_text_pair.last, href_text_pair.first
-      end.join('; ').html_safe
-    end
-
     def map_argon_code(inst, context, value)
       TrlnArgon::LookupManager.instance.map([inst, context, value].join('.'))
     end
@@ -85,7 +77,27 @@ module TrlnArgon
       end.compact
     end
 
+    def link_to_secondary_urls(options = {})
+      options[:value].map do |url|
+        link_text = if url[:text].present?
+                      url[:text]
+                    else
+                      url[:href]
+                    end
+        link_to link_text, url[:href]
+      end.join('<br />').html_safe
+    end
+
+    def link_to_primary_url(url_hash)
+      link_to(primary_url_text(url_hash), url_hash[:href], class: "link-type-#{url_hash[:type]}")
+    end
+
     private
+
+    def primary_url_text(url_hash)
+      return url_hash[:text] if url_hash[:text].present?
+      I18n.t('trln_argon.online_access')
+    end
 
     def online_access_link_text(url_hrefs, url_text)
       if url_text && url_text.count == url_hrefs.count

--- a/lib/trln_argon/solr_field_defaults.yml
+++ b/lib/trln_argon/solr_field_defaults.yml
@@ -710,6 +710,10 @@ ROLLUP_ID:
   solr_field: rollup_id
   label:
     en: Rollup ID
+SECONDARY_URLS:
+  solr_field: secondary_urls
+  label:
+    en: Links
 SERIES:
   solr_field: :series_a
   label:
@@ -962,26 +966,10 @@ UPC:
   solr_field: :upc_a
   label:
     en: Upc
-URL_HREF:
-  solr_field: :url_href_a
+URLS:
+  solr_field: url_a
   label:
-    en: Link
-URL_HREF_STR:
-  solr_field: :url_href_str
-  label:
-    en: URL HREF Str
-URL_REL:
-  solr_field: :url_rel_a
-  label:
-    en: URL Rel
-URL_TEXT:
-  solr_field: :url_text_a
-  label:
-    en: URL Text
-URL_TEXT_T:
-  solr_field: :url_text_t
-  label:
-    en: URL Text T
+    en: Links
 VOLUME_DATE_RANGE:
   solr_field: :volume_date_range_a
   label:

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.2.14'.freeze
+  VERSION = '0.2.15'.freeze
 end

--- a/spec/helpers/trln_argon_helper_spec.rb
+++ b/spec/helpers/trln_argon_helper_spec.rb
@@ -118,135 +118,25 @@ describe TrlnArgonHelper do
     end
   end
 
-  describe '#url_href_with_url_text_link' do
-    context 'when we show single link without text' do
-      let(:document) do
-        SolrDocument.new(
-          id: 'DUKE12345'
-        )
-      end
-      let(:options) do
-        { value:    ['http://www.firstlink.edu'],
-          document: document }
-      end
-
-      it 'generates a link using the default text' do
-        expect(helper.url_href_with_url_text_link(options)).to(
-          eq('<a href="http://www.firstlink.edu">Online Access</a>')
-        )
-      end
+  describe '#link_to_subject_segments' do
+    let(:options) do
+      { value:    ['Technology -- History -- Science',
+                   'Galilei, Galileo, 1564-1642'] }
     end
+    let(:context) { CatalogController.new }
 
-    context 'when we show a single link with text' do
-      let(:document) do
-        SolrDocument.new(
-          id:         'DUKE12345',
-          url_text_a: ['First Link']
-        )
-      end
-      let(:options) do
-        { value:    ['http://www.firstlink.edu'],
-          document: document }
-      end
-
-      it 'generates a link using the supplied text value' do
-        expect(helper.url_href_with_url_text_link(options)).to(
-          eq('<a href="http://www.firstlink.edu">First Link</a>')
-        )
-      end
-    end
-
-    context 'when we render multiple links each without a text value' do
-      let(:document) do
-        SolrDocument.new(
-          id: 'DUKE12345'
-        )
-      end
-      let(:options) do
-        { value:    ['http://www.firstlink.edu',
-                     'http://www.secondlink.edu',
-                     'http://www.thirdlink.edu'],
-          document: document }
-      end
-
-      it 'generates all the links using the default text value' do
-        expect(helper.url_href_with_url_text_link(options)).to(
-          eq('<a href="http://www.firstlink.edu">Online Access</a>; '\
-             '<a href="http://www.secondlink.edu">Online Access</a>; '\
-             '<a href="http://www.thirdlink.edu">Online Access</a>')
-        )
-      end
-    end
-
-    context 'when there are multiple links each with a text value' do
-      let(:document) do
-        SolrDocument.new(
-          id: 'DUKE12345',
-          url_text_a: ['First Link',
-                       'Second Link',
-                       'Third Link']
-        )
-      end
-      let(:options) do
-        { value:    ['http://www.firstlink.edu',
-                     'http://www.secondlink.edu',
-                     'http://www.thirdlink.edu'],
-          document: document }
-      end
-
-      it 'generates each link with its own text value' do
-        expect(helper.url_href_with_url_text_link(options)).to(
-          eq('<a href="http://www.firstlink.edu">First Link</a>; '\
-             '<a href="http://www.secondlink.edu">Second Link</a>; '\
-             '<a href="http://www.thirdlink.edu">Third Link</a>')
-        )
-      end
-    end
-
-    context 'when there are multiple links with a different number of text values' do
-      let(:document) do
-        SolrDocument.new(
-          id: 'DUKE12345',
-          url_text_a: ['A Link',
-                       'Another Link']
-        )
-      end
-      let(:options) do
-        { value:    ['http://www.firstlink.edu',
-                     'http://www.secondlink.edu',
-                     'http://www.thirdlink.edu'],
-          document: document }
-      end
-
-      it 'generates all the links using the default text value' do
-        expect(helper.url_href_with_url_text_link(options)).to(
-          eq('<a href="http://www.firstlink.edu">Online Access</a>; '\
-             '<a href="http://www.secondlink.edu">Online Access</a>; '\
-             '<a href="http://www.thirdlink.edu">Online Access</a>')
-        )
-      end
-    end
-
-    describe '#link_to_subject_segments' do
-      let(:options) do
-        { value:    ['Technology -- History -- Science',
-                     'Galilei, Galileo, 1564-1642'] }
-      end
-      let(:context) { CatalogController.new }
-
-      it 'generates links to a search for each segment' do
-        allow(context).to receive(:local_filter_applied?).and_return(false)
-        allow(context).to receive(:search_action_url).and_return('/catalog?begins_with=something')
-        expect(context.helpers.link_to_subject_segments(options)).to(
-          eq(['<a title="Technology" href="/catalog?begins_with=something">Technology</a> -- '\
-              '<a title="Technology -- History" href="/catalog?begins_with=something">'\
-              '<span class="sr-only">Technology -- </span>History</a> -- '\
-              '<a title="Technology -- History -- Science" href="/catalog?begins_with=something">'\
-              '<span class="sr-only">Technology -- History -- </span>Science</a>',
-              '<a title="Galilei, Galileo, 1564-1642" href="/catalog?begins_with=something">'\
-              'Galilei, Galileo, 1564-1642</a>'])
-        )
-      end
+    it 'generates links to a search for each segment' do
+      allow(context).to receive(:local_filter_applied?).and_return(false)
+      allow(context).to receive(:search_action_url).and_return('/catalog?begins_with=something')
+      expect(context.helpers.link_to_subject_segments(options)).to(
+        eq(['<a title="Technology" href="/catalog?begins_with=something">Technology</a> -- '\
+            '<a title="Technology -- History" href="/catalog?begins_with=something">'\
+            '<span class="sr-only">Technology -- </span>History</a> -- '\
+            '<a title="Technology -- History -- Science" href="/catalog?begins_with=something">'\
+            '<span class="sr-only">Technology -- History -- </span>Science</a>',
+            '<a title="Galilei, Galileo, 1564-1642" href="/catalog?begins_with=something">'\
+            'Galilei, Galileo, 1564-1642</a>'])
+      )
     end
   end
 
@@ -269,6 +159,60 @@ describe TrlnArgonHelper do
           eq('Duke, duke.facet.blah, duke.facet.foo')
         )
       end
+    end
+  end
+
+  describe '#link_to_primary_url' do
+    context 'url data includes text' do
+      let(:url_hash) do
+        { href: 'http://www.law.duke.edu/journals/lcp/',
+          type: 'fulltext',
+          text: 'Law and contemporary problems, v. 63, no. 1-2' }
+      end
+
+      it 'creates a link using the supplied text' do
+        expect(helper.link_to_primary_url(url_hash)).to(
+          eq('<a class="link-type-fulltext" '\
+             'href="http://www.law.duke.edu/journals/lcp/">'\
+             'Law and contemporary problems, v. 63, no. 1-2</a>')
+        )
+      end
+    end
+
+    context 'url data does not include text' do
+      let(:url_hash) do
+        { href: 'http://www.law.duke.edu/journals/lcp/',
+          type: 'fulltext',
+          text: '' }
+      end
+
+      it 'creates a link using the default translation' do
+        expect(helper.link_to_primary_url(url_hash)).to(
+          eq('<a class="link-type-fulltext" '\
+             'href="http://www.law.duke.edu/journals/lcp/">'\
+             'Online Access</a>')
+        )
+      end
+    end
+  end
+
+  describe '#link_to_secondary_urls' do
+    let(:options) do
+      { value: [{ href: 'http://www.law.duke.edu/journals/lcp/',
+                  type: 'other',
+                  text: 'Law and contemporary problems, v. 63, no. 1-2' },
+                { href: 'http://www.law.duke.edu/journals/lcp/',
+                  type: 'other',
+                  text: '' }] }
+    end
+
+    it 'creates links to secondary urls' do
+      expect(helper.link_to_secondary_urls(options)).to(
+        eq('<a href="http://www.law.duke.edu/journals/lcp/">'\
+           'Law and contemporary problems, v. 63, no. 1-2</a><br />'\
+           '<a href="http://www.law.duke.edu/journals/lcp/">'\
+           'http://www.law.duke.edu/journals/lcp/</a>')
+      )
     end
   end
 end

--- a/spec/lib/trln_argon/solr_document_spec.rb
+++ b/spec/lib/trln_argon/solr_document_spec.rb
@@ -30,4 +30,67 @@ describe TrlnArgon::SolrDocument do
       end
     end
   end
+
+  describe 'url' do
+    context 'field contains multiple complete url data' do
+      let(:solr_document) do
+        SolrDocumentTestClass.new(
+          id: 'DUKE12345',
+          url_a: ['{"href":"http://www.law.duke.edu/journals/lcp/",'\
+                  '"type":"other",'\
+                  '"text":"Law and contemporary problems, v. 63, no. 1-2"}',
+                  '{"href":"http://www.law.duke.edu/journals/lcp/",'\
+                  '"type":"other",'\
+                  '"text":"Law and contemporary problems, v. 63, no. 1-2"}',
+                  '{"href":"http://www.law.duke.edu/journals/lcp/",'\
+                  '"type":"other",'\
+                  '"text":"Law and contemporary problems, v. 63, no. 1-2"}']
+        )
+      end
+
+      it 'deserializes each of the url entries' do
+        expect(solr_document.urls).to(
+          eq([{ href: 'http://www.law.duke.edu/journals/lcp/',
+                type: 'other',
+                text: 'Law and contemporary problems, v. 63, no. 1-2' },
+              { href: 'http://www.law.duke.edu/journals/lcp/',
+                type: 'other',
+                text: 'Law and contemporary problems, v. 63, no. 1-2' },
+              { href: 'http://www.law.duke.edu/journals/lcp/',
+                type: 'other',
+                text: 'Law and contemporary problems, v. 63, no. 1-2' }])
+        )
+      end
+    end
+
+    context 'field contains incomplete url data' do
+      let(:solr_document) do
+        SolrDocumentTestClass.new(
+          id: 'DUKE12345',
+          url_a: ['{"href":"http://purl.access.gpo.gov/GPO/LPS606","type":"fulltext"}']
+        )
+      end
+
+      it 'deserializes each of the url entries and sets the missing keys' do
+        expect(solr_document.urls).to(
+          eq([{ href: 'http://purl.access.gpo.gov/GPO/LPS606', type: 'fulltext', text: '' }])
+        )
+      end
+    end
+
+    context 'field contains some values not parsable as JSON' do
+      let(:solr_document) do
+        SolrDocumentTestClass.new(
+          id: 'DUKE12345',
+          url_a: ['a', nil, '{"href":"http://purl.access.gpo.gov/GPO/LPS606","type":"fulltext"}']
+        )
+      end
+
+      it 'deserializes each of the parsable URL entries and rejects unparsable values' do
+        expect(solr_document.urls).to(
+          eq([{ href: 'http://purl.access.gpo.gov/GPO/LPS606', type: 'fulltext', text: '' }])
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a first pass at handling serialized URL data in the UI. For now I'm displaying fulltext and findingaid links under "Where to find it" and related and other links under "More Details." Not doing anything with thumbnails for now.