### PR TITLE
Apply local_filter to inital searches; Constraint display fixes.

### DIFF
--- a/app/helpers/search_history_constraints_helper.rb
+++ b/app/helpers/search_history_constraints_helper.rb
@@ -1,0 +1,3 @@
+module SearchHistoryConstraintsHelper
+  include TrlnArgon::ViewHelpers::SearchHistoryConstraintsHelperBehavior
+end

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -15,6 +15,9 @@
     <%= form_tag search_action_url, method: :get, class: 'search-query-form clearfix navbar-form', role: 'search' do %>
 
       <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+      <% unless search_state.params_for_search.key?(:local_filter) %>
+        <%= hidden_field_tag :local_filter, TrlnArgon::Engine.configuration.apply_local_filter_by_default %>
+      <% end %>
 
       <div class="row">
 

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -14,8 +14,6 @@ module TrlnArgon
       send(:include, LocalFilter)
       send(:include, BlacklightAdvancedSearch::Controller)
 
-      before_action :set_local_filter_param_to_default, only: %i[index show]
-
       helper_method :query_has_constraints?
 
       add_show_tools_partial(:email,
@@ -98,7 +96,7 @@ module TrlnArgon
                                collapse: false
         config.add_facet_field TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.to_s,
                                label: TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.label,
-                               filter_element_helper: :location_filter_display,
+                               helper_method: :location_filter_display,
                                partial: 'blacklight/hierarchy/facet_hierarchy',
                                collapse: false
         config.add_facet_field TrlnArgon::Fields::FORMAT_FACET.to_s,
@@ -172,7 +170,7 @@ module TrlnArgon
         cnf_components = TrlnArgon::Fields::CALL_NUMBER_FACET.to_s.split('_')
         lf_components = TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.to_s.split('_')
         config.facet_display[:hierarchy] = {
-          # blacklight-hiearchy requires this mapping;
+          # blacklight-hierarchy requires this mapping;
           # prefix + final component (separated by _)
           cnf_components[0..-2].join('_') => [[cnf_components[-1]], ':'],
           lf_components[0..-2].join('_') => [[lf_components[-1]], ':']

--- a/lib/trln_argon/controller_override/local_filter.rb
+++ b/lib/trln_argon/controller_override/local_filter.rb
@@ -4,8 +4,9 @@ module TrlnArgon
       extend ActiveSupport::Concern
 
       included do
-        before_action :set_local_filter_param_to_default, only: %i[index show]
+        before_action :set_local_filter_param_to_default, only: %i[index]
         before_action :filtered_results_total, only: :index
+
         helper_method :filter_scope_name
         helper_method :local_filter_applied?
       end
@@ -21,16 +22,59 @@ module TrlnArgon
       end
 
       def local_filter_applied?
-        if params.key?(:local_filter)
-          params[:local_filter].to_s == 'true'
+        if local_filter_param_present?
+          params[:local_filter] == 'true'
         elsif current_search_session_has_local_filter?
-          current_search_session.try(:query_params).fetch('local_filter').to_s == 'true'
+          current_search_session.query_params['local_filter'] == 'true'
         else
           local_filter_default.to_s == 'true'
         end
       end
 
+      # Override method mixed into CatalogController from Blacklight
+      # Blacklight::Controller
+      # This override ensures that the local_filter param with
+      # the default value is added to all search actions URLs
+      # unless it is already set.
+      def search_action_url(options = {})
+        merge_local_filter_param(options)
+        super
+      end
+
+      # Override method mixed into CatalogController from Blacklight
+      # Blacklight::Controller
+      # This override ensures that the local_filter param with
+      # the default value is added to all facet action URLs
+      # unless it is already set.
+      def search_facet_url(options = {})
+        merge_local_filter_param(options)
+        super
+      end
+
+      # Override method mixed into CatalogController from Blacklight
+      # Blacklight::SearchContext
+      # This override ensures that local_filter is saved as a parameter
+      # in search history even if not set in the URL.
+      def find_or_initialize_search_session_from_params(params)
+        params_copy = params.reject { |k, v| blacklisted_search_session_params.include?(k.to_sym) || v.blank? }
+
+        return if params_copy.reject { |k, _v| %i[action controller].include? k.to_sym }.blank?
+
+        saved_search = searches_from_history.find { |x| x.query_params == params_copy }
+
+        merge_local_filter_param(params_copy)
+
+        saved_search || Search.create(query_params: params_copy).tap do |s|
+          add_to_search_history(s)
+        end
+      end
+
       private
+
+      def set_local_filter_param_to_default
+        return if local_filter_param_present?
+        params[:local_filter] = local_filter_default.to_s
+      end
 
       def filtered_results_total
         @filtered_results_total ||=
@@ -65,14 +109,9 @@ module TrlnArgon
           end
       end
 
-      def set_local_filter_param_to_default
-        return if local_filter_param_present?
-        params[:local_filter] = local_filter_default.to_s
-      end
-
       def current_search_session_has_local_filter?
         current_search_session.present? &&
-          current_search_session.try(:query_params) &&
+          current_search_session.respond_to?(:query_params) &&
           current_search_session.try(:query_params).key?('local_filter')
       end
 
@@ -82,6 +121,11 @@ module TrlnArgon
 
       def local_filter_whitelist
         %w[true false]
+      end
+
+      def merge_local_filter_param(options = {})
+        return if options.key?(:local_filter)
+        options.merge!(local_filter: local_filter_default)
       end
 
       def local_filter_default

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.3.4'.freeze
+  VERSION = '0.3.5'.freeze
 end

--- a/lib/trln_argon/view_helpers.rb
+++ b/lib/trln_argon/view_helpers.rb
@@ -3,7 +3,10 @@ module TrlnArgon
     autoload :BlacklightHelperBehavior, 'trln_argon/view_helpers/blacklight_helper_behavior'
     autoload :CatalogHelperBehavior, 'trln_argon/view_helpers/catalog_helper_behavior'
     autoload :HierarchyHelper, 'trln_argon/view_helpers/hierarchy_helper'
-    autoload :RenderConstraintsHelperBehavior, 'trln_argon/view_helpers/render_constraints_helper_behavior'
+    autoload :RenderConstraintsHelperBehavior,
+             'trln_argon/view_helpers/render_constraints_helper_behavior'
+    autoload :SearchHistoryConstraintsHelperBehavior,
+             'trln_argon/view_helpers/search_history_constraints_helper_behavior'
     autoload :TrlnArgonHelper, 'trln_argon/view_helpers/trln_argon_helper'
   end
 end

--- a/lib/trln_argon/view_helpers/render_constraints_helper_behavior.rb
+++ b/lib/trln_argon/view_helpers/render_constraints_helper_behavior.rb
@@ -13,35 +13,6 @@ module TrlnArgon
       end
 
       ##
-      # Render a single facet's constraint
-      #
-      # @param [String] facet field
-      # @param [Array<String>] selected facet values
-      # @param [Hash] query parameters
-      # @return [String]
-      def render_filter_element(facet, values, _localized_params)
-        facet_config = facet_configuration_for_field(facet)
-
-        safe_join(values.map do |val|
-          next if val.blank? # skip empty string
-          display_value = filter_element_display_value(facet_config, facet, val)
-          render_constraint_element(
-            facet_field_label(facet_config.key), display_value,
-            remove: search_action_path(search_state.remove_facet_params(facet, val)),
-            classes: ['filter', 'filter-' + facet.parameterize]
-          )
-        end, "\n")
-      end
-
-      def filter_element_display_value(facet_config, facet, val)
-        if facet_config.filter_element_helper
-          send(facet_config.filter_element_helper, facet_display_value(facet, val))
-        else
-          facet_display_value(facet, val)
-        end
-      end
-
-      ##
       # Render the begins_with constraints
       #
       # @param [Hash] query parameters

--- a/lib/trln_argon/view_helpers/search_history_constraints_helper_behavior.rb
+++ b/lib/trln_argon/view_helpers/search_history_constraints_helper_behavior.rb
@@ -1,0 +1,25 @@
+module TrlnArgon
+  module ViewHelpers
+    # Override default BL SearchHistoryConstraintsHelperBehavior
+    module SearchHistoryConstraintsHelperBehavior
+      include Blacklight::SearchHistoryConstraintsHelperBehavior
+
+      def render_search_to_s(params)
+        super + render_search_to_s_begins_with_filters(params)
+      end
+
+      # Render the begins with facet constraints
+      def render_search_to_s_begins_with_filters(params)
+        return ''.html_safe unless params[:begins_with]
+
+        safe_join(params[:begins_with].collect do |facet_field, value_list|
+          render_search_to_s_element("#{I18n.t('trln_argon.search_constraints.begins_with')} "\
+                                     "#{facet_field_label(facet_field)}",
+                                     safe_join(value_list.collect do |value|
+                                       render_filter_value(value, facet_field)
+                                     end, content_tag(:span, " #{t('blacklight.and')} ", class: 'filterSeparator')))
+        end, " \n ")
+      end
+    end
+  end
+end

--- a/spec/features/full_records_spec.rb
+++ b/spec/features/full_records_spec.rb
@@ -30,8 +30,23 @@ describe 'full records' do
       expect(page).to have_css('dt.blacklight-isbn_with_qualifying_info', text: 'ISBN:')
     end
 
-    it 'displays the ISBN field value' do
-      expect(page).to have_css('dd.blacklight-isbn_with_qualifying_info', text: /.+/)
+    it 'displays the ISBN field value with qualifying info' do
+      expect(page).to have_css(
+        'dd.blacklight-isbn_with_qualifying_info',
+        text: '0195069714 (cloth : alk. paper) and 0195069722 (pbk. : alk paper)'
+      )
+    end
+  end
+
+  context 'when viewing a rolled up record' do
+    before { visit solr_document_path(id: 'DUKE002952265', local_filter: false) }
+
+    it 'shows location information for Duke' do
+      expect(page).to have_css('#doc_duke002952265 h3', text: 'Duke Libraries')
+    end
+
+    it 'shows location information for NCSU' do
+      expect(page).to have_css('#doc_duke002952265 h3', text: 'NCSU Libraries')
     end
   end
 

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -55,6 +55,18 @@ describe 'search results' do
     end
   end
 
+  context 'when location facet applied to search' do
+    before do
+      visit search_catalog_path(local_filter: 'false')
+      click_button 'search'
+      click_link 'Law Libraries'
+    end
+
+    it 'displays the full location name in the page title' do
+      expect(page.title).to have_content(/Location: Law Libraries.*/)
+    end
+  end
+
   describe 'paging controls' do
     before do
       visit search_catalog_path(local_filter: 'false')
@@ -67,6 +79,29 @@ describe 'search results' do
 
     it 'provides paging options below the search results' do
       expect(page).to have_css('.pagination')
+    end
+  end
+
+  describe 'date facet filters' do
+    before do
+      visit search_catalog_path(local_filter: false)
+      click_link 'Publication Year'
+    end
+
+    it 'provides "2000 to present" date range facet' do
+      expect(page).to have_css('#facet-publication_year_isort_stored_single .facet_select', text: '2000 to present')
+    end
+
+    it 'provides "1900 to 1999" date range facet' do
+      expect(page).to have_css('#facet-publication_year_isort_stored_single .facet_select', text: '1900 to 1999')
+    end
+
+    it 'provides "1800 to 1899" date range facet' do
+      expect(page).to have_css('#facet-publication_year_isort_stored_single .facet_select', text: '1800 to 1899')
+    end
+
+    it 'provides "Before 1800" date range facet' do
+      expect(page).to have_css('#facet-publication_year_isort_stored_single .facet_select', text: 'Before 1800')
     end
   end
 

--- a/spec/lib/trln_argon/controller_override_spec.rb
+++ b/spec/lib/trln_argon/controller_override_spec.rb
@@ -290,4 +290,27 @@ describe TrlnArgon::ControllerOverride do
       end
     end
   end
+
+  describe '#local_filter_applied?' do
+    it 'uses the local_filter value from params if present and valid' do
+      allow(mock_controller).to receive(:params).and_return(local_filter: 'false')
+      expect(mock_controller.local_filter_applied?).to be false
+    end
+
+    # rubocop:disable VerifiedDoubles
+    it 'uses the local_filter value set in current_search_session if present' do
+      allow(mock_controller).to receive(:params).and_return(nothing: 'here')
+      allow(mock_controller).to receive(:current_search_session_has_local_filter?).and_return(true)
+      allow(mock_controller).to receive(:current_search_session).and_return(
+        double(query_params: { q: 'query', f: 'facets', controller: 'catalog', local_filter: 'false' })
+      )
+      expect(mock_controller.local_filter_applied?).to be false
+    end
+
+    it 'uses the default local_filter value when param and session not set' do
+      allow(mock_controller).to receive(:local_filter_param_present?).and_return(false)
+      allow(mock_controller).to receive(:current_search_session_has_local_filter?).and_return(false)
+      expect(mock_controller.local_filter_applied?).to be true
+    end
+  end
 end


### PR DESCRIPTION
- Ensures that local_filter is applied correctly to initial searches.
- Local_filter is added to search session so that in-context (show view) paging works as expected.
- Location facet values now display correctly in the page title (codes were displayed before).
- Adds tests for recent bug-fixes to help prevent regression.