### PR TITLE
add heath check controller at `/health`

### DIFF
--- a/app/controllers/trln_argon/healthchecks_controller.rb
+++ b/app/controllers/trln_argon/healthchecks_controller.rb
@@ -1,0 +1,35 @@
+require_dependency 'trln_argon/application_controller'
+
+module TrlnArgon
+  class HealthchecksController < ::ApplicationController
+    @cache = ActiveSupport::Cache::MemoryStore.new(expires_in: 3.minutes)
+
+    # rubocop:disable MethodLength
+    def index
+      result = self.class.ping
+      if result.nil?
+        render json: { status: 'FAILED' }, status: 500
+      else
+        count = begin
+                  result['response']['numFound']
+                rescue StandardError
+                  'unknown'
+                end
+        render json: { status: 'OK', count: count }
+      end
+    end
+    # rubocop:enable MethodLength
+
+    def self.ping
+      @cache.fetch(:ping) do
+        begin
+          solr = ENV['SOLR_URL']
+          return nil unless solr
+          (RSolr.connect url: solr).get('select', params: { rows: 0 })
+        rescue StandardError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
+  scope module: 'trln_argon' do
+    resources :healthchecks, path: '/health', action: :index
+  end
   mount BlacklightAdvancedSearch::Engine => '/'
 end

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.3.34'.freeze
+  VERSION = '0.3.40'.freeze
 end


### PR DESCRIPTION
Does a very basic query against solr to get a record count, returns `{ status: OK, count: (record count) }` with HTTP 200 if it succeeds, or `{ status: FAILED }` with HTTP 500 if Solr can't be queried.

This requires less processing than checking the front page, which may improve performance behind an ELB (which runs checks fairly often).