### PR TITLE
add escape_query_string to default processing chains

### DIFF
--- a/app/models/default_local_search_builder.rb
+++ b/app/models/default_local_search_builder.rb
@@ -1,4 +1,5 @@
 class DefaultLocalSearchBuilder < SearchBuilder
-  self.default_processor_chain += %i[show_only_local_holdings
+  self.default_processor_chain += %i[escape_query_string
+                                     show_only_local_holdings
                                      begins_with_filter]
 end

--- a/app/models/default_trln_search_builder.rb
+++ b/app/models/default_trln_search_builder.rb
@@ -1,4 +1,5 @@
 class DefaultTrlnSearchBuilder < SearchBuilder
-  self.default_processor_chain += %i[rollup_duplicate_records
+  self.default_processor_chain += %i[escape_query_string
+                                     rollup_duplicate_records
                                      begins_with_filter]
 end

--- a/app/models/local_only_search_builder.rb
+++ b/app/models/local_only_search_builder.rb
@@ -1,3 +1,3 @@
 class LocalOnlySearchBuilder < SearchBuilder
-  self.default_processor_chain += [:show_only_local_holdings]
+  self.default_processor_chain += %i[escape_query_string show_only_local_holdings]
 end

--- a/app/models/record_mailer.rb
+++ b/app/models/record_mailer.rb
@@ -4,7 +4,7 @@ class RecordMailer < ActionMailer::Base
   def email_record(documents, details, url_gen_params)
     title = begin
               documents.first[TrlnArgon::Fields::TITLE_MAIN]
-            rescue
+            rescue StandardError
               I18n.t('blacklight.email.text.default_title')
             end
     subject = I18n.t('blacklight.email.text.subject', count: documents.length, title: title)

--- a/app/models/trln_argon_search_builder.rb
+++ b/app/models/trln_argon_search_builder.rb
@@ -1,0 +1,6 @@
+class TrlnArgonSearchBuilder < SearchBuilder
+  self.default_processor_chain += %i[escape_query_string
+                                     apply_local_filter
+                                     boost_isxn_matches
+                                     begins_with_filter]
+end

--- a/app/models/trln_argon_search_builder.rb
+++ b/app/models/trln_argon_search_builder.rb
@@ -1,6 +1,0 @@
-class TrlnArgonSearchBuilder < SearchBuilder
-  self.default_processor_chain += %i[escape_query_string
-                                     apply_local_filter
-                                     boost_isxn_matches
-                                     begins_with_filter]
-end

--- a/lib/trln_argon/argon_search_builder.rb
+++ b/lib/trln_argon/argon_search_builder.rb
@@ -1,3 +1,4 @@
+require 'trln_argon/argon_search_builder/query_escape'
 require 'trln_argon/argon_search_builder/add_query_to_solr'
 require 'trln_argon/argon_search_builder/begins_with'
 require 'trln_argon/argon_search_builder/local_filter'
@@ -6,6 +7,7 @@ module TrlnArgon
   # Shared SearchBuilder behaviors concerning record rollup,
   # local record filtering, and ISxN match boosting.
   module ArgonSearchBuilder
+    include QueryEscape
     include AddQueryToSolr
     include BeginsWith
     include LocalFilter

--- a/lib/trln_argon/argon_search_builder/query_escape.rb
+++ b/lib/trln_argon/argon_search_builder/query_escape.rb
@@ -1,0 +1,10 @@
+module TrlnArgon
+  module ArgonSearchBuilder
+    module QueryEscape
+
+      def escape_query_string(solr_parameters)
+        solr_parameters[:q] = RSolr.solr_escape(solr_parameters[:q]) if solr_parameters[:q]
+      end
+    end
+  end
+end

--- a/lib/trln_argon/argon_search_builder/query_escape.rb
+++ b/lib/trln_argon/argon_search_builder/query_escape.rb
@@ -1,7 +1,6 @@
 module TrlnArgon
   module ArgonSearchBuilder
     module QueryEscape
-
       def escape_query_string(solr_parameters)
         solr_parameters[:q] = RSolr.solr_escape(solr_parameters[:q]) if solr_parameters[:q]
       end


### PR DESCRIPTION
This 'works' with the examples given on TD-659 but I am not 100% clear on whether I added the escaping logic to the right SearchBuilder implementations.  That aspect deserves special scrutiny.
