### PR TITLE
Seems to fix the search with colon issue without breaking advanced fielded search

### DIFF
--- a/config/initializers/blacklight_advanced_search.rb
+++ b/config/initializers/blacklight_advanced_search.rb
@@ -1,4 +1,4 @@
-# Yet another Solr 7 BL compatibility hack.
+# Solr 7.2 BL compatibility hack.
 # Forces BL Advanced Search to specify
 # local params query type as edismax.
 module BlacklightAdvancedSearch
@@ -6,8 +6,27 @@ module BlacklightAdvancedSearch
     # rubocop:disable ClassAndModuleChildren
     module ParsingNesting::Tree
       class Node
+        # rubocop:disable MethodLength
+        # rubocop:disable AbcSize
+        def build_nested_query(embeddables, solr_params = {}, options = {})
+          options = { always_nested: true,
+                      force_deftype: 'dismax' }.merge(options)
+
+          # if it's pure negative, we need to transform
+          if embeddables.find_all { |n| n.is_a?(ExcludedClause) }.length == embeddables.length
+            negated = NotExpression.new(List.new(embeddables.collect(&:operand), options[:force_deftype]))
+            solr_params = solr_params.merge(mm: '1')
+            return negated.to_query(solr_params)
+          else
+            collected_embeddables = embeddables.collect(&:to_embed).join(' ')
+            inner_query = build_local_params(solr_params, options[:force_deftype]) +
+                          TrlnArgon::SolrEscape.escape_colon_after_space(collected_embeddables)
+            return ('_query_:"' + bs_escape(inner_query) + '"') if options[:always_nested]
+            return inner_query
+          end
+        end
+
         def build_local_params(hash = {}, _force_deftype = 'edismax')
-          puts hash.inspect
           if !hash.empty?
             '{!edismax ' + hash.collect { |k, v| "#{k}=#{v.to_s.include?(' ') ? "'" + v + "'" : v}" }.join(' ') + '}'
           else

--- a/lib/trln_argon.rb
+++ b/lib/trln_argon.rb
@@ -12,6 +12,7 @@ module TrlnArgon
   autoload :Lookups, 'trln_argon/mappings'
   autoload :MappingsGitFetcher, 'trln_argon/mappings'
   autoload :SolrDocument, 'trln_argon/solr_document'
+  autoload :SolrEscape, 'trln_argon/solr_escape'
   autoload :SyndeticsData, 'trln_argon/syndetics_data'
   autoload :TrlnControllerBehavior, 'trln_argon/trln_controller_behavior'
   autoload :ViewHelpers, 'trln_argon/view_helpers'

--- a/lib/trln_argon/argon_search_builder/add_query_to_solr.rb
+++ b/lib/trln_argon/argon_search_builder/add_query_to_solr.rb
@@ -3,7 +3,7 @@ module TrlnArgon
     module AddQueryToSolr
       ##
       # NOTE: This is an override of the Blacklight SearchBuilder
-      #       method of the same name to address the Solr 7
+      #       method of the same name to address the Solr 7.2+
       #       local params compatibility issue.
       #
       #       Applying approach proposed here:
@@ -47,14 +47,14 @@ module TrlnArgon
                                   "{!lucene}NOT *:*"
                                 else
                                   "{!lucene}" + q.map do |field, values|
-                                    "#{field}:(#{Array(values).map { |x| solr_param_quote(x) }.join(' OR ')})"
+                                    "#{field}:(#{Array(values).map { |x| solr_param_quote(TrlnArgon::SolrEscape.escape_colon_after_space(x)) }.join(' OR ')})"
                                   end.join(" AND ")
                                 end
 
           solr_parameters[:defType] = 'lucene'
           solr_parameters[:spellcheck] = 'false'
         elsif blacklight_params[:q]
-          solr_parameters[:q] = blacklight_params[:q]
+          solr_parameters[:q] = TrlnArgon::SolrEscape.escape_colon_after_space(blacklight_params[:q])
         end
       end
 
@@ -69,12 +69,12 @@ module TrlnArgon
         solr_parameters[:defType] = 'lucene' # to enable parsing of local params
         local_params = if search_field.solr_local_parameters.present?
                          search_field.solr_local_parameters.map do |key, val|
-                           key.to_s + "=" + solr_param_quote(val, quote: "'")
+                           key.to_s + "=" + solr_param_quote(TrlnArgon::SolrEscape.escape_colon_after_space(val), quote: "'")
                          end.join(" ")
                        else
                          ''
                        end
-        solr_parameters[:q] = "{!#{q_parser}#{local_params}}#{blacklight_params[:q]}"
+        solr_parameters[:q] = "{!#{q_parser}#{local_params}}#{TrlnArgon::SolrEscape.escape_colon_after_space(blacklight_params[:q])}"
       end
     end
   end

--- a/lib/trln_argon/solr_escape.rb
+++ b/lib/trln_argon/solr_escape.rb
@@ -1,0 +1,14 @@
+module TrlnArgon
+  module SolrEscape
+    # Example: 'foo : foo' => 'foo \\: foo'
+    # Escaping ' :' to ' \\:' prevents Solr edismax query parser
+    # from parsing 'foo : foo' into foo:[[66 6f 6f] TO [66 6f 6f]]
+    def self.escape_colon_after_space(str)
+      str.gsub(/\s:/, ' \\\\:')
+    end
+
+    def self.unescape_colon_after_space(str)
+      str.gsub(/\s\\:/, ' :')
+    end
+  end
+end

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.4.8'.freeze
+  VERSION = '0.4.9'.freeze
 end

--- a/spec/lib/trln_argon/solr_escape_spec.rb
+++ b/spec/lib/trln_argon/solr_escape_spec.rb
@@ -1,0 +1,21 @@
+describe TrlnArgon::SolrEscape do
+  describe 'escape_colon_after_space' do
+    let(:raw_query) { "100 years of the Nineteenth Amendment : an appraisal of women's political activism" }
+
+    it 'escapes colons preceded by a space' do
+      expect(described_class.escape_colon_after_space(raw_query)).to eq(
+        '100 years of the Nineteenth Amendment \\: an appraisal of women\'s political activism'
+      )
+    end
+  end
+
+  describe 'unescape_colon_after_space' do
+    let(:escaped_query) { "100 years of the Nineteenth Amendment \\: an appraisal of women's political activism" }
+
+    it 'unescapes colons preceded by a space' do
+      expect(described_class.unescape_colon_after_space(escaped_query)).to eq(
+        '100 years of the Nineteenth Amendment : an appraisal of women\'s political activism'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Not convinced this is a permanent solution, but it works for now.

Also recommend setting default `uf` (user field) to ```uf=-*```. This prevents Solr from interpreting queries like "foo:foo" as a fielded search.