### PR TITLE
add helpers for availability status classes and due-date

### DIFF
--- a/app/views/catalog/_items_section_index.html.erb
+++ b/app/views/catalog/_items_section_index.html.erb
@@ -131,7 +131,7 @@
                     <dl class="dl-horizontal">
                       <dt><span class='status-label label label-info'><%= t('trln_argon.show.label.status') %></span></dt>
                       <dd>
-                       <% available_class= item_availability_display(item)  + '-boop' %>
+                       <% available_class= item_availability_display(item) %>
                        <% due_date = item_due_date(item) %>
                        <span class="<%= available_class %>">
                            <%= item['status'] %>

--- a/app/views/catalog/_items_section_index.html.erb
+++ b/app/views/catalog/_items_section_index.html.erb
@@ -112,7 +112,11 @@
                 <% items_have_notes = items_have_notes?(item_data['items']) %>
                 <% item_data['items'].each do |item| %>
 
-                <div class="col-md-12 item <%= loc_n %> <%= loc_b %>">
+                    <div class="col-md-12 item <%= loc_n %> <%= loc_b %>"
+                        <% if item.has_key?('item_id') %>
+                         data-item-barcode="<%= item['item_id'] %>"
+                     <% end %>
+                         >
 
                   <% # --- ITEM(s) --- %>
 
@@ -127,15 +131,14 @@
                     <dl class="dl-horizontal">
                       <dt><span class='status-label label label-info'><%= t('trln_argon.show.label.status') %></span></dt>
                       <dd>
-                        <% if item['status'].downcase == 'available' || item['status'].downcase == 'available - library use only' %>
-                          <span class="item-available"><%= item['status'] %></span>
-                        <% elsif item['status'].downcase == 'checked out' || item['status'].include?('lost') %>
-                          <span class="item-not-available"><%= item['status'] %> <% if item.has_key?('due_date') %> (Due <%= item['due_date'].to_time.strftime("%m/%d/%Y") %>)<% end %> </span>
-                        <% elsif item['status'].downcase == 'in-library use only' %>
-                          <span class="item-library-only"><%= item['status'] %></span>
-                        <% else %>
-                          <%= item['status'] %>
-                        <% end %>
+                       <% available_class= item_availability_display(item)  + '-boop' %>
+                       <% due_date = item_due_date(item) %>
+                       <span class="<%= available_class %>">
+                           <%= item['status'] %>
+                           <% if !due_date.empty? %>
+                               <span class='due-date'><%= due_date %></span>
+                           <% end %>
+                       </span>
                       </dd>
                     </dl>
                   </div>

--- a/app/views/catalog/_items_section_show.html.erb
+++ b/app/views/catalog/_items_section_show.html.erb
@@ -102,8 +102,10 @@
 
           <% item_data['items'].each_with_index do |item, index| %>
 
-            <div class="col-md-12 item <%= loc_n %> <%= loc_b %>">
-
+              <div class="col-md-12 item <%= loc_n %> <%= loc_b %>"
+                   <% if item.has_key?('item_id') %>
+                       data-item-barcode="<%= item['item_id'] %>"
+                   <% end %>>
               <% # --- ITEM(s) --- %>
 
               <div class='col-md-4 col-sm-7 call-number-wrapper'>
@@ -117,15 +119,15 @@
                 <dl class="dl-horizontal">
                   <dt><span class='status-label label label-info'><%= t('trln_argon.show.label.status') %></span></dt>
                   <dd>
-                    <% if item['status'].downcase == 'available' || item['status'].downcase == 'available - library use only' %>
-                      <span class="item-available"><%= item['status'] %></span>
-                    <% elsif item['status'].downcase == 'checked out' || item['status'].downcase.include?('lost') %>
-                      <span class="item-not-available"><%= item['status'] %> <% if item.has_key?('due_date') %> (Due <%= item['due_date'].to_time.strftime("%m/%d/%Y") %>)<% end %> </span>
-                    <% elsif item['status'].downcase == 'in-library use only' %>
-                      <span class="item-library-only"><%= item['status'] %></span>
-                    <% else %>
-                      <%= item['status'] %>
-                    <% end %>
+                  <% availability_class = item_availability_display(item) %>
+                  <% due_date = item_due_date(item) %>
+                    <span class="<%= availability_class %>">
+                        <%= item['status'] %>
+                        <% unless due_date.empty? %>
+                            <span class="due-date">
+                             <%= due_date %>
+                            </span>
+                        <% end %>
                   </dd>
                 </dl>
               </div>

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.5.20'.freeze
+  VERSION = '0.5.21'.freeze
 end

--- a/lib/trln_argon/view_helpers/trln_argon_helper.rb
+++ b/lib/trln_argon/view_helpers/trln_argon_helper.rb
@@ -65,9 +65,9 @@ module TrlnArgon
         case item['status']
         when /^available/i
           'item-available'
-        when /^checked out/i, /lost/i, /^missing/i
+        when /^checked out/i, /\blost\b/i, /^missing/i
           'item-not-available'
-        when /^in-library use only$/i
+        when /(?:in-)?library use only/i
           'item-library-only'
         else
           'item-availability-misc'
@@ -75,7 +75,7 @@ module TrlnArgon
       end
 
       def item_due_date(item)
-        return '' unless item.has_key?('due_date')
+        return '' unless item.key?('due_date')
         dfmt = item['due_date'].to_date.strftime('%m/%d/%Y')
         "(Due #{dfmt})"
       rescue StandardError

--- a/lib/trln_argon/view_helpers/trln_argon_helper.rb
+++ b/lib/trln_argon/view_helpers/trln_argon_helper.rb
@@ -61,6 +61,28 @@ module TrlnArgon
         t('trln_argon.consortium.long_name')
       end
 
+      def item_availability_display(item)
+        case item['status']
+        when /^available/i
+          'item-available'
+        when /^checked out/i, /lost/i, /^missing/i
+          'item-not-available'
+        when /^in-library use only$/i
+          'item-library-only'
+        else
+          'item-availability-misc'
+        end
+      end
+
+      def item_due_date(item)
+        return '' unless item.has_key?('due_date')
+        dfmt = item['due_date'].to_date.strftime('%m/%d/%Y')
+        "(Due #{dfmt})"
+      rescue StandardError
+        # not a date?
+        "(Due #{item['due_date']})"
+      end
+
       def map_argon_code(inst, context, value)
         TrlnArgon::LookupManager.instance.map([inst, context, value].join('.'))
       end


### PR DESCRIPTION
Helper can be overridden; uses case-insenstitive regexes to match status strings to CSS classes.

Adds data-item-barcode (will not show, but can be used to display barcodes).