### PR TITLE
Configurable checkbox facet:

### DIFF
--- a/app/assets/javascripts/trln_argon/enable_facet_checkbox.js
+++ b/app/assets/javascripts/trln_argon/enable_facet_checkbox.js
@@ -1,0 +1,77 @@
+Blacklight.onLoad(function() {
+
+  $(window).load(function(){
+
+    var numCheckboxes = $('.facet-checkbox-wrapper').length;
+
+    if (numCheckboxes) {
+
+      $( '.facet-checkbox-wrapper' ).each( function( index, element ) {
+
+          facet_field = $( this ).data("facet-field");
+          checkbox_field = $( this ).data("checkbox-field");
+
+          if (facet_field != undefined) {
+
+            $(".blacklight-" + facet_field + " .panel-heading").hide();
+
+            var facetChecked = false;
+            var theParam = "f%5B" + facet_field + "%5D%5B%5D=" + checkbox_field;
+
+            // check if url param exists, add checked status
+            if (window.location.href.indexOf(theParam) > -1) {
+              $("#checkbox_" + facet_field).attr("checked", "checked");
+              $(".blacklight-" + facet_field).addClass("checkbox-facet");
+              $(".blacklight-" + facet_field).addClass("facet_limit-active checkbox-facet-checked");
+              facetChecked = true;
+            } else {
+              $("#checkbox_" + facet_field).removeAttr("checked", "checked");
+              $(".blacklight-" + facet_field).addClass("checkbox-facet");
+              $(".blacklight-" + facet_field).removeClass("facet_limit-active checkbox-facet-checked");
+            }
+
+            $("#checkbox_" + facet_field).click( function() {
+
+              var theOGURL = window.location.href.toString();
+
+              if (facetChecked == true) { // already checked
+
+                if (window.location.href.indexOf("?" + theParam + "&") > -1) {
+                  theParam = "?" + theParam;
+                  var theNewURL = theOGURL.replace(theParam, "?");
+
+                } else if (window.location.href.indexOf("?" + theParam) > -1) {
+                  theParam = "?" + theParam;
+                  var theNewURL = theOGURL.replace(theParam, "");
+
+                } else {
+                  theParam = "&" + theParam;
+                  var theNewURL = theOGURL.replace(theParam, "");
+                }
+
+                window.location.href = theNewURL;
+
+              } else {
+
+                if (window.location.href.indexOf("?") > -1) {
+                  var theNewURL = theOGURL + "&" + theParam;
+
+                } else {
+                  var theNewURL = theOGURL + "?" + theParam;
+                }
+
+                window.location.href = theNewURL;
+
+              } // END already checked
+
+            }); // click function
+
+          } // END facet_field defined
+
+      }); // END .facet-checkbox-wrapper loop
+
+    } // END numCheckboxes
+
+  }); // END window.load
+
+}); // END Blacklight.onLoad

--- a/app/assets/javascripts/trln_argon/trln_argon.js
+++ b/app/assets/javascripts/trln_argon/trln_argon.js
@@ -1,6 +1,7 @@
 //= require trln_argon/holdings.js
 //= require trln_argon/syndetics.js
 //= require trln_argon/expand_contract.js
+//= require trln_argon/enable_facet_checkbox.js
 //= require trln_argon/progressive_links.js
 //= require trln_argon/location_facet.js
 //= require trln_argon/physical_media_facet.js

--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -737,6 +737,61 @@ dd[aria-expanded=true] .expandable-content-controls .show-control.less {
     font-weight: normal;
   }
 
+  .facet-checkbox-wrapper {
+
+    .facet-label {
+      color: $primary-link-color;
+      input, label {
+        cursor: pointer;
+        font-weight: normal;
+      }
+      input {
+        font-size: 1.2em;
+      }
+      label:hover {
+        text-decoration: underline;
+      }
+    }
+    .facet-count {
+      float: right;
+    }
+
+  }
+
+  .facet-content .panel-body {
+    border-top: 0 !important;
+  }
+
+  .checkbox-facet {
+    .facet-content .panel-body {
+      border-top: 0 !important;
+    }
+  }
+
+  .facet-checkbox-wrapper {
+
+    .facet-label label,
+    .facet-count {
+      margin-bottom: 0;
+    }
+
+    .facet-label input {
+      margin-right: .15em;
+    }
+
+  }
+
+  .checkbox-facet-checked {
+    background: $primary-link-color;
+    border: $secondary-color;
+
+    .facet-label label,
+    .facet-count {
+      color: #fff;
+    }
+
+  }
+
   /* END Facets */
 
 

--- a/app/views/catalog/_facet_checkbox.html.erb
+++ b/app/views/catalog/_facet_checkbox.html.erb
@@ -1,0 +1,20 @@
+<% # renders checkbox for facet -%>
+
+<% checkbox_field = blacklight_config[:facet_fields][facet_field.key.parameterize]['locals'][:checkbox_field] %>
+<% checkbox_field_label = blacklight_config[:facet_fields][facet_field.key.parameterize]['locals'][:checkbox_field_label] %>
+
+<!-- params for JS - pass as data attributes-->
+<%= content_tag :div, id: "checkbox_wrapper_#{facet_field.key.parameterize}",
+                      class: "facet-checkbox-wrapper",
+                      data: { facet_field: facet_field.key.parameterize,
+                              checkbox_field: checkbox_field } do %>
+
+   <span class="facet-label">
+    <%= check_box_tag "checkbox_#{facet_field.key.parameterize}", "1", false %>
+    <%= label_tag "checkbox_#{facet_field.key.parameterize}" do %>
+      <%= checkbox_field_label %></span>
+    <% end %>
+  </span>
+  <span class="facet-count"><%= display_facet_hit_count(facet_field.key.parameterize, checkbox_field) %></span>
+
+<% end %>

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -125,6 +125,9 @@ en:
             begins_with: "begins with"
             location_separator: ", "
 
+        checkbox_facets:
+            online: "Available Online"
+
         search:
             zero_results:
                 title: 'No results available at %{local_institution_name}'

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -100,11 +100,15 @@ module TrlnArgon
         # Facets to be populated on landing page
         config.add_home_facet_field TrlnArgon::Fields::ACCESS_TYPE_FACET.to_s,
                                     label: TrlnArgon::Fields::ACCESS_TYPE_FACET.label,
-                                    collapse: false
+                                    collapse: false,
+                                    show: true,
+                                    partial: 'catalog/facet_checkbox',
+                                    locals: { checkbox_field: 'Online', checkbox_field_label: 'Available Online' }
         config.add_home_facet_field TrlnArgon::Fields::AVAILABLE_FACET.to_s,
                                     label: TrlnArgon::Fields::AVAILABLE_FACET.label,
                                     limit: true,
-                                    collapse: false
+                                    collapse: false,
+                                    show: true
         config.add_home_facet_field TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.to_s,
                                     label: TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.label,
                                     helper_method: :location_filter_display,
@@ -135,11 +139,15 @@ module TrlnArgon
         # Facets to be populated when search performed
         config.add_facet_field TrlnArgon::Fields::ACCESS_TYPE_FACET.to_s,
                                label: TrlnArgon::Fields::ACCESS_TYPE_FACET.label,
-                               collapse: false
+                               collapse: false,
+                               show: true,
+                               partial: 'catalog/facet_checkbox',
+                               locals: { checkbox_field: 'Online', checkbox_field_label: 'Available Online' }
         config.add_facet_field TrlnArgon::Fields::AVAILABLE_FACET.to_s,
                                label: TrlnArgon::Fields::AVAILABLE_FACET.label,
                                limit: true,
-                               collapse: false
+                               collapse: false,
+                               show: true
         config.add_facet_field TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.to_s,
                                label: TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.label,
                                helper_method: :location_filter_display,

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -103,7 +103,7 @@ module TrlnArgon
                                     collapse: false,
                                     show: true,
                                     partial: 'catalog/facet_checkbox',
-                                    locals: { checkbox_field: 'Online', checkbox_field_label: 'Available Online' }
+                                    locals: { checkbox_field: 'Online', checkbox_field_label: I18n.t('trln_argon.checkbox_facets.online') }
         config.add_home_facet_field TrlnArgon::Fields::AVAILABLE_FACET.to_s,
                                     label: TrlnArgon::Fields::AVAILABLE_FACET.label,
                                     limit: true,
@@ -142,7 +142,7 @@ module TrlnArgon
                                collapse: false,
                                show: true,
                                partial: 'catalog/facet_checkbox',
-                               locals: { checkbox_field: 'Online', checkbox_field_label: 'Available Online' }
+                               locals: { checkbox_field: 'Online', checkbox_field_label: I18n.t('trln_argon.checkbox_facets.online') }
         config.add_facet_field TrlnArgon::Fields::AVAILABLE_FACET.to_s,
                                label: TrlnArgon::Fields::AVAILABLE_FACET.label,
                                limit: true,

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.5.24'.freeze
+  VERSION = '0.5.25'.freeze
 end

--- a/lib/trln_argon/view_helpers/trln_argon_helper.rb
+++ b/lib/trln_argon/view_helpers/trln_argon_helper.rb
@@ -160,6 +160,16 @@ module TrlnArgon
         options[:value].join(', ')
       end
 
+      def display_facet_hit_count(the_facet, the_value)
+        hits = facets_from_request.select { |f| f.name == the_facet }
+                                  .map(&:items)
+                                  .first
+                                  .select { |i| i.value == the_value }
+                                  .map(&:hits)
+                                  .first
+        hits.present? ? number_with_delimiter(hits, delimiter: ',') : '0'
+      end
+
       private
 
       def primary_url_text(url_hash)

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -71,6 +71,13 @@ describe 'search results' do
     end
   end
 
+  context 'when checkbox facet is configured' do
+    it 'renders a checkbox field in the facet' do
+      visit search_catalog_path
+      expect(page).to have_selector(:css, '#checkbox_access_type_f')
+    end
+  end
+
   # removed for brittleness, leaving in as an example of
   # how to select a search field.
   # describe 'when showing results' do


### PR DESCRIPTION
- configured for Access Type

- to make changes, in controller_override.rb find the config for the facet, set options as listed below. 'your-checkbox-field' should be the name of the field that you want the checkbox to control. So for example with the Access Type facet, we would could choose 'Online' for that value. 'your-label-field' would be the label text for the rendered checkbox, so something like 'Available Online.' Note if the facet your configuring is a 'home-facet', you'll need to set the options twice.

  show: true,
  partial: 'catalog/facet_checkbox',
  locals: { checkbox_field: 'your-checkbox-field', checkbox_field_label: 'your-label-text' }

- To disable the checkbox, remove the partial and locals from the config.