### PR TITLE
limits the number of items displayed:

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ FEEDBACK_URL: ''
 #Define the order of institutions in holding list. Your institution should go first.
 SORT_ORDER_IN_HOLDING_LIST: 'unc, duke, ncsu, nccu, trln'
 NUMBER_OF_LOCATION_FACETS: '10'
+NUMBER_OF_ITEMS_INDEX_VIEW: '3'
+NUMBER_OF_ITEMS_SHOW_VIEW: '6'
 ```
 
 ### Changing Styles

--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -361,24 +361,29 @@ body {
 
 
 
-.expander[aria-expanded=false] .hider {
+.expander[aria-expanded=false].hider {
     display: none;
 }
 
-.expander[aria-expanded=false] .shower {
-    display: inline;
+.expander[aria-expanded=false].shower {
+    display: inline-block;
 }
 
-.expander[aria-expanded=true] .hider {
-    display: inline;
+.expander[aria-expanded=true].hider {
+    display: inline-block;
 }
 
-.expander[aria-expanded=true] .shower {
+.expander[aria-expanded=true].shower {
     display: none;
 }
 
 .item-group {
-    display: none;
+  display: none;
+}
+
+.item-group-display {
+  overflow: hidden;
+  clear: both;
 }
 
 /**
@@ -426,7 +431,7 @@ dd[aria-expanded=true] .expandable-content-controls .show-control.less {
 }
 
 .summary-text-wrapper.contracted:after {
-  background: linear-gradient(to right, rgba(243, 243, 243, 0), rgba(243, 243, 243, 1) 50%);
+  background: linear-gradient(to right, rgba(243, 243, 243, 0), rgba(237, 237, 237, 1) 50%);
 }
 
 
@@ -1117,7 +1122,6 @@ h1, h2, h3, h4, h5 {
   }
 
   .item:nth-child(n+1):before,
-  .location-narrow-group:before,
   .loc-narrow-banner:before {
     display: block;
     content: '';
@@ -1126,8 +1130,27 @@ h1, h2, h3, h4, h5 {
     margin: 0 15px 0 15px;
   }
 
+  .has-summary .item:nth-child(1):before {
+    border-top: none;
+  }
+
+
+
   .institution-availability .item:nth-child(n+1):before {
     margin: 0 0 0 0;
+  }
+
+  .location-narrow-group {
+    background: rgba(0,0,0,.03);
+    margin-left: 30px;
+    margin-right: 30px;
+    width: calc(100% - 60px);
+    padding: 0;
+    margin-bottom: 0;
+    margin-top: 5px;
+    padding-top: 7px;
+    padding-bottom: 5px;
+    border: 1px solid rgba(0,0,0,.05);
   }
 
 
@@ -1181,6 +1204,10 @@ h1, h2, h3, h4, h5 {
     margin-right: .25em;
   }
 
+  .location-narrow-group .label {
+    background: rgba(255,255,255,.9);
+  }
+
   .status-wrapper {
     /*display: inline-block;*/
   }
@@ -1215,6 +1242,14 @@ h1, h2, h3, h4, h5 {
 
   .item-library-only {
     color: $alt-available-color;
+  }
+
+  .item-availability-misc {
+    color: $misc-available-color;
+  }
+
+  .items-toggle {
+    margin-top: .5em;
   }
 
 }
@@ -1397,37 +1432,13 @@ div.marc-record {
 }
 
 
-
-
-
 /* Results Display */
 
-.items .collapse.in {
-  margin: 0 15px 0 15px;
-  padding-top: 1.5em;
-  padding-bottom: 1.5em;
-
-  .call-number-wrapper,
-  .status-wrapper,
-  .item-note-wrapper,
-  .item {
-    padding-right: 0;
-    padding-left: 0;
-  }
-
-  .item:before {
-    margin-right: 0 !important;
-    margin-left: 0 !important;
-  }
-
+.item-note-wrapper {
+  clear: both;
 }
 
 .items .loc-narrow-banner a.expander {
-  /*padding: 3px 6px 3px 6px;
-  background-color: #e3e3e3;
-  margin-left: 5px;
-  font-size: 90%;
-  color: #333;*/
   white-space: nowrap;
   min-width: 100%;
   margin-top: 1em;

--- a/app/assets/stylesheets/trln_argon/trln_argon_variables_defaults.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_variables_defaults.scss
@@ -26,6 +26,7 @@ $facet-grey: #f5f5f5 !default; // use in facets and results lists
 $available-color: #157d1e !default; // default is green
 $not-available-color: #b11f1f !default; // default is red
 $alt-available-color: #7d6816 !default; // default is brown
+$misc-available-color: #9b4e1b !default; // default is orange
 
 
 // Institution Colors:

--- a/app/views/catalog/_items_section_index.html.erb
+++ b/app/views/catalog/_items_section_index.html.erb
@@ -2,11 +2,13 @@
   <div class="items-spacer col-md-12"></div>
 <% end %>
 
+<% num_display_items = TrlnArgon::Engine.configuration.number_of_items_index_view.to_f %>
+
 <div class="items-wrapper items-section-index col-md-12">
 
   <div class="row">
 
-        <% document.holdings.each do |loc_b, loc_narrow_map| %>
+        <% document.holdings.each_with_index do |(loc_b, loc_narrow_map), document_index| %>
 
           <% next if (loc_b == 'ONLINE' || loc_b == 'DUKIR' || loc_b.blank?) %>
 
@@ -14,8 +16,6 @@
 
             <% next if item_data.fetch('items', []).empty? %>
 
-            <% has_holding_notes = !item_data.fetch('notes', '').blank? %>
-            <% has_summary = !item_data.fetch('summary', '').blank? %>
             <% narrow_loc = map_argon_code(document.record_owner, 'loc_n', loc_n) %>
 
 
@@ -44,123 +44,75 @@
               </h4>
             </div>
 
-
             <% # --- SUMMARY --- %>
-            <% if has_summary %>
 
-              <div class="row">
+            <% has_holding_notes = !item_data.fetch('notes', '').blank? %>
+            <% has_summary = !item_data.fetch('summary', '').blank? %>
+            <% has_call_no = !item_data.fetch('call_no', '').blank? %>
 
-                <div class='location-narrow-group col-md-12'>
+            <% if has_summary || has_holding_notes || has_call_no %>
 
-                  <div class='col-md-4 call-number-wrapper'>
-                    <dl class="dl-horizontal">
-                      <dt><span class='call-number-label label label-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
-                      <dd><span class='call-number'><%= item_data['call_no'] %></span></dd>
-                    </dl>
-                  </div>
+              <% item_with_summary = true %>
 
-                  <div class='col-md-8 summary-wrapper'>
+              <%= render partial: "items_section_summary", locals: { document: document, loc_b: loc_b, loc_n: loc_n, item_data: item_data, has_holding_notes: has_holding_notes } %>
 
-                    <dl class="dl-horizontal">
-                      <dt><span class='summary-label label label-info'><%= t('trln_argon.show.label.summary') %></span></dt>
-                      <dd>
-                        <div class='summary-holdings'>
+            <% end %>
 
-                          <div class='summary-text-wrapper expandable-content'>
-                            <%= item_data['summary'].gsub(' ', '&nbsp;').html_safe %>
-                          </div>
+            <% # ---ITEMS WRAPPER --- %>
 
-                        <% if item_data['summary'].length > 200 %>
-                          <div class="expandable-content-controls">
-                            <div class='item-summary-link'>
-                              <%= link_to ("read more <i class='fa fa-chevron-circle-right' aria-hidden='true'></i>").html_safe, controller: "catalog", action: 'show', id: document.id, anchor: "item-summary-#{loc_b}-#{loc_n}" %>
-                            </div>
-                          </div>
-                        <% end %>
+              <div class="item-group-display <%= item_with_summary ? 'has-summary' : '' %>" id="<%= document.id %>-<%= document_index %>-preview">
 
-                          <div class='item-details-link'><%= link_to t('trln_argon.show.controls.details'), controller: "catalog", action: 'show', id: document.id, anchor: "item-container-#{loc_b}-#{loc_n}" %></div>
-                        </div>
-                      </dd>
+                <% items_have_notes = items_have_notes?(item_data['items']) %>
 
-                    </dl>
+                <% item_data['items'].first(num_display_items).each do |item| %>
 
-                  </div>
+                  <div class="col-md-12 item <%= loc_n %> <%= loc_b %>" data-item-barcode="<%= item.has_key?('item_id') ? item['item_id'] : '' %>">
 
-                <% if has_holding_notes %>
-
-                  <div class='holding-note col-md-12'>
-
-                    <dl class="dl-horizontal">
-                      <dt><span class='holding-note-label label label-info'><%= t('trln_argon.show.label.holding_note') %></span></dt>
-                      <dd><%= [*item_data['notes']].join("; "); %></dd>
-                    </dl>
+                    <%= render partial: "items_section_item", locals: { document: document, item: item, loc_b: loc_b, loc_n: loc_n, source: 'index' } %>
 
                   </div>
 
                 <% end %>
+
+              </div>
+
+              <% if item_data['items'].size > num_display_items %>
+
+                <div class='item-group-display collapse' id="item-container-<%=document.id %>-<%= document_index %>">
+
+                  <% item_data['items'].each_with_index do |item, i| %>
+
+                    <% next if i < num_display_items %>
+
+                    <div class="col-md-12 item <%= loc_n %> <%= loc_b %>">
+
+                      <%= render partial: "items_section_item", locals: { document: document, item: item, loc_b: loc_b, loc_n: loc_n, source: 'index' } %>
+
+                    </div>
+
+                  <% end %>
 
                 </div>
 
-              </div>
+                <div class="col-md-12">
+                  <div class="items-toggle">
 
-            <% end %>
+                    <a href="javascript:void(0);" class="expander btn btn-sm btn-info shower" data-toggle='collapse' data-target='<%= "#item-container-#{document.id}-#{document_index}" %>' aria-expanded='false' aria-controls='this'>
+                      <%= t('trln_argon.show.controls.show') %> <%= t('trln_argon.show.controls.all') %> <%= item_data['items'].length %> <%= t('trln_argon.show.controls.items') %> <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                    </a>
 
+                    <a href="#<%= document.id %>-<%= document_index %>-preview" class="expander btn btn-sm btn-info hider" data-toggle='collapse' data-target='<%= "#item-container-#{document.id}-#{document_index}" %>' aria-expanded='false' aria-controls='this'>
+                      <%= t('trln_argon.show.controls.hide') %> <%= t('trln_argon.show.controls.items') %> <i class="fa fa-minus-circle" aria-hidden="true"></i>
+                    </a>
 
-
-            <% # --- NO SUMMARY --- %>
-            <% unless has_summary %>
-
-              <div class='item-group-display row' id="<%= "item-container-#{loc_b}-#{loc_n}" %>">
-                <% items_have_notes = items_have_notes?(item_data['items']) %>
-                <% item_data['items'].each do |item| %>
-
-                    <div class="col-md-12 item <%= loc_n %> <%= loc_b %>"
-                        <% if item.has_key?('item_id') %>
-                         data-item-barcode="<%= item['item_id'] %>"
-                     <% end %>
-                         >
-
-                  <% # --- ITEM(s) --- %>
-
-                  <div class='col-md-5 col-sm-5 call-number-wrapper'>
-                    <dl class="dl-horizontal">
-                    <dt><span class='call-number-label label label-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
-                    <dd><span class='call-number'><%= call_number_display(item) %></span> <%= render partial: 'location_link', locals: { document: document, loc_b: loc_b, loc_n: loc_n, item: item } %></dd>
-                    </dl>
                   </div>
-
-                  <div class='col-md-7 col-sm-7 status-wrapper'>
-                    <dl class="dl-horizontal">
-                      <dt><span class='status-label label label-info'><%= t('trln_argon.show.label.status') %></span></dt>
-                      <dd>
-                       <% available_class= item_availability_display(item) %>
-                       <% due_date = item_due_date(item) %>
-                       <span class="<%= available_class %>">
-                           <%= item['status'] %>
-                           <% if !due_date.empty? %>
-                               <span class='due-date'><%= due_date %></span>
-                           <% end %>
-                       </span>
-                      </dd>
-                    </dl>
-                  </div>
-
-                <% if item_notes_display(item).present? %>
-                  <div class="col-md-12 item-note-wrapper">
-                    <dl class="dl-horizontal">
-                      <dt><span class='item-note-label label label-info'><%= t('trln_argon.show.label.item_note') %></span></dt>
-                      <dd><%= item_notes_display(item) %></dd>
-                    </dl>
-                  </div>
-                <% end %>
-
-              </div>
+                </div>
 
               <% end %>
 
-            </div>
+          <% # -- END items wrapper -- %>
 
-            <% end %>
+
 
       <% end %>
 

--- a/app/views/catalog/_items_section_index.html.erb
+++ b/app/views/catalog/_items_section_index.html.erb
@@ -48,9 +48,8 @@
 
             <% has_holding_notes = !item_data.fetch('notes', '').blank? %>
             <% has_summary = !item_data.fetch('summary', '').blank? %>
-            <% has_call_no = !item_data.fetch('call_no', '').blank? %>
 
-            <% if has_summary || has_holding_notes || has_call_no %>
+            <% if has_summary || has_holding_notes %>
 
               <% item_with_summary = true %>
 

--- a/app/views/catalog/_items_section_item.html.erb
+++ b/app/views/catalog/_items_section_item.html.erb
@@ -1,0 +1,61 @@
+<% # --- ITEM --- %>
+
+<% if source == 'show' %>
+  <div class='col-md-4 col-sm-7 call-number-wrapper'>
+<% else %>
+  <div class='col-md-5 col-sm-5 call-number-wrapper'>
+<% end %>
+    <dl class="dl-horizontal">
+    <dt><span class='call-number-label label label-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
+    <dd><span class='call-number'><%= call_number_display(item) %></span> <%= render partial: 'location_link', locals: { document: document, loc_b: loc_b, loc_n: loc_n, item: item } %></dd>
+    </dl>
+  </div>
+
+<% if source == 'show' %>
+  <div class='col-md-4 col-sm-5 status-wrapper'>
+<% else %>
+  <div class='col-md-7 col-sm-7 status-wrapper'>
+<% end %>
+    <dl class="dl-horizontal">
+      <dt><span class='status-label label label-info'><%= t('trln_argon.show.label.status') %></span></dt>
+      <dd>
+       <% available_class= item_availability_display(item) %>
+       <% due_date = item_due_date(item) %>
+       <span class="<%= available_class %>">
+           <%= item['status'] %>
+           <% if !due_date.empty? %>
+               <span class='due-date'><%= due_date %></span>
+           <% end %>
+       </span>
+      </dd>
+    </dl>
+
+  </div>
+
+<% if item_notes_display(item).present? %>
+
+  <% if source == 'show' %>
+
+    <% if item_notes_display(item).length > 120 %>
+  <div class="col-md-12 item-note-wrapper">
+    <% else %>
+  <div class="col-md-4 col-sm-12 item-note-wrapper">
+    <% end %>
+      <dl class="dl-horizontal">
+        <dt><span class='item-note-label label label-info'><%= t('trln_argon.show.label.item_note') %></span></dt>
+        <dd><%= item_notes_display(item) %></dd>
+      </dl>
+  </div>
+
+  <% else %>
+
+  <div class="col-md-12 item-note-wrapper">
+    <dl class="dl-horizontal">
+      <dt><span class='item-note-label label label-info'><%= t('trln_argon.show.label.item_note') %></span></dt>
+      <dd><%= item_notes_display(item) %></dd>
+    </dl>
+  </div>
+
+  <% end %>
+
+<% end %>

--- a/app/views/catalog/_items_section_show.html.erb
+++ b/app/views/catalog/_items_section_show.html.erb
@@ -43,9 +43,8 @@
 
         <% has_holding_notes = !item_data.fetch('notes', '').blank? %>
         <% has_summary = !item_data.fetch('summary', '').blank? %>
-        <% has_call_no = !item_data.fetch('call_no', '').blank? %>
 
-        <% if has_summary || has_holding_notes || has_call_no %>
+        <% if has_summary || has_holding_notes %>
 
           <% item_with_summary = true %>
 

--- a/app/views/catalog/_items_section_show.html.erb
+++ b/app/views/catalog/_items_section_show.html.erb
@@ -2,20 +2,19 @@
   <div class="items-spacer col-md-12"></div>
 <% end %>
 
+<% num_display_items = TrlnArgon::Engine.configuration.number_of_items_show_view.to_f %>
+
 <div class="items-wrapper items-section-show col-md-12">
 
   <div class="row">
 
-    <% document.holdings.each do |loc_b, loc_narrow_map| %>
+    <% document.holdings.each_with_index do |(loc_b, loc_narrow_map), document_index| %>
 
       <% next if (loc_b == 'ONLINE' || loc_b == 'DUKIR' || loc_b.blank?) %>
 
       <% loc_narrow_map.each do |loc_n, item_data|  %>
 
         <% next if item_data.fetch('items', []).empty? %>
-
-        <% has_holding_notes = !item_data.fetch('notes', '').blank? %>
-        <% has_summary = !item_data.fetch('summary', '').blank? %>
 
         <div class="location-header col-md-12">
           <h3>
@@ -42,126 +41,73 @@
         </div>
 
 
-        <% if has_summary %>
+        <% has_holding_notes = !item_data.fetch('notes', '').blank? %>
+        <% has_summary = !item_data.fetch('summary', '').blank? %>
+        <% has_call_no = !item_data.fetch('call_no', '').blank? %>
 
-          <% # --- SUMMARY --- %>
-          <div class="row">
+        <% if has_summary || has_holding_notes || has_call_no %>
 
-            <div class='loc-narrow-banner col-md-12' data-locbroad='<%= loc_b %>' data-locnarrow='<%= loc_n %>' id='<%= "item-details-#{loc_b}-#{loc_n}" %>'>
+          <% item_with_summary = true %>
 
-              <div class='col-sm-4 call-number-wrapper'>
-                <dl class="dl-horizontal">
-                  <dt><span class='call-number-label label label-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
-                  <dd><span class='call-number'><%= item_data['call_no'] %></span></dd>
-                </dl>
-              </div>
-
-              <div class='col-sm-8 summary-wrapper'>
-                <dl class="dl-horizontal" id="item-summary-<%= loc_b %>-<%= loc_n %>">
-                  <dt><span class='summary-label label label-info'><%= t('trln_argon.show.label.summary') %></span></dt>
-                  <dd>
-
-                    <div class="summary-text-wrapper expandable-content">
-                      <span class="summary-text"><%= item_data['summary'].gsub(' ', '&nbsp;').html_safe %></span>
-                    </div>
-
-                    <div class="expandable-content-controls">
-                      <span class='show-control more'><a href="javascript:void(0);" class="btn btn-show"><%= t('trln_argon.show.controls.show_more') %> <i class="fa fa-chevron-circle-down" aria-hidden="true"></i></a></span>
-                      <span class='show-control less'><a href="#item-summary-<%= loc_b %>-<%= loc_n %>" class="btn btn-hide"><%= t('trln_argon.show.controls.show_less') %> <i class="fa fa-chevron-circle-up" aria-hidden="true"></i></a></span>
-                    </div>
-
-                  </dd>
-
-                </dl>
-                <div class="summary-toggle text-center">
-                  <a class="expander btn btn-sm btn-info" data-toggle='collapse' href='<%= "#item-container-#{loc_b}-#{loc_n}" %>' aria-expanded='false' aria-controls='this'>
-                    <span class='shower'><%= t('trln_argon.show.controls.show') %> <%= item_data['items'].length %> <%= t('trln_argon.show.controls.items') %> <i class="fa fa-plus-circle" aria-hidden="true"></i></span>
-                    <span class='hider'><%= t('trln_argon.show.controls.hide') %> <%= t('trln_argon.show.controls.items') %> <i class="fa fa-minus-circle" aria-hidden="true"></i></span>
-                  </a>
-                </div>
-              </div>
-
-            <% if has_holding_notes %>
-              <div class="col-sm-12 holding-note">
-                <dl class="dl-horizontal">
-                  <dt><span class='holding-note-label label label-info'><%= t('trln_argon.show.label.holding_note') %></span></dt>
-                  <dd><span class='notes'><%= [*item_data['notes']].join("; "); %></span></dd>
-                </dl>
-              </div>
-            <% end %>
-
-            </div>
-
-          </div>
+          <%= render partial: "items_section_summary", locals: { document: document, loc_b: loc_b, loc_n: loc_n, item_data: item_data, has_holding_notes: has_holding_notes } %>
 
         <% end %>
 
-        <div class="row item-group<%= has_summary ? '' : '-display' %>" id="<%= "item-container-#{loc_b}-#{loc_n}" %>">
 
-          <% items_have_notes = items_have_notes?(item_data['items']) %>
 
-          <% item_data['items'].each_with_index do |item, index| %>
+        <% # ---ITEMS WRAPPER (new) --- %>
 
-              <div class="col-md-12 item <%= loc_n %> <%= loc_b %>"
-                   <% if item.has_key?('item_id') %>
-                       data-item-barcode="<%= item['item_id'] %>"
-                   <% end %>>
-              <% # --- ITEM(s) --- %>
+          <div class="item-group-display <%= item_with_summary ? 'has-summary' : '' %>" id="<%= document.id %>-<%= document_index %>-preview">
 
-              <div class='col-md-4 col-sm-7 call-number-wrapper'>
-                <dl class="dl-horizontal">
-                  <dt><span class='call-number-label label label-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
-                  <dd><span class='call-number'><%= call_number_display(item) %></span> <%= render partial: 'location_link', locals: { document: document, loc_b: loc_b, loc_n: loc_n, item: item } %></dd>
-                </dl>
+            <% items_have_notes = items_have_notes?(item_data['items']) %>
+
+            <% item_data['items'].first(num_display_items).each do |item| %>
+
+              <div class="col-md-12 item <%= loc_n %> <%= loc_b %>" data-item-barcode="<%= item.has_key?('item_id') ? item['item_id'] : '' %>">
+
+                <%= render partial: "items_section_item", locals: { document: document, item: item, loc_b: loc_b, loc_n: loc_n, source: 'show' } %>
+
               </div>
 
-              <div class='col-md-4 col-sm-5 status-wrapper'>
-                <dl class="dl-horizontal">
-                  <dt><span class='status-label label label-info'><%= t('trln_argon.show.label.status') %></span></dt>
-                  <dd>
-                  <% availability_class = item_availability_display(item) %>
-                  <% due_date = item_due_date(item) %>
-                    <span class="<%= availability_class %>">
-                        <%= item['status'] %>
-                        <% unless due_date.empty? %>
-                            <span class="due-date">
-                             <%= due_date %>
-                            </span>
-                        <% end %>
-                  </dd>
-                </dl>
-              </div>
-
-            <% if item_notes_display(item).present? %>
-
-              <% if item_notes_display(item).length > 120 %>
-                <div class="col-md-12 item-note-wrapper">
-              <% else %>
-                <div class="col-md-4 col-sm-12 item-note-wrapper">
-              <% end %>
-                  <dl class="dl-horizontal">
-                    <dt><span class='item-note-label label label-info'><%= t('trln_argon.show.label.item_note') %></span></dt>
-                    <dd><%= item_notes_display(item) %></dd>
-                  </dl>
-              </div>
             <% end %>
 
+          </div>
+
+          <% if item_data['items'].size > num_display_items %>
+
+            <div class='item-group-display collapse' id="item-container-<%=document.id %>-<%= document_index %>">
+
+              <% item_data['items'].each_with_index do |item, i| %>
+
+                <% next if i < num_display_items %>
+
+                <div class="col-md-12 item <%= loc_n %> <%= loc_b %>">
+
+                  <%= render partial: "items_section_item", locals: { document: document, item: item, loc_b: loc_b, loc_n: loc_n, source: 'show' } %>
+
+                </div>
+
+              <% end %>
+
+            </div>
+
+            <div class="col-md-12">
+              <div class="items-toggle">
+
+                <a href="javascript:void(0);" class="expander btn btn-sm btn-info shower" data-toggle='collapse' data-target='<%= "#item-container-#{document.id}-#{document_index}" %>' aria-expanded='false' aria-controls='this'>
+                  <%= t('trln_argon.show.controls.show') %> <%= t('trln_argon.show.controls.all') %> <%= item_data['items'].length %> <%= t('trln_argon.show.controls.items') %> <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                </a>
+
+                <a href="#<%= document.id %>-<%= document_index %>-preview" class="expander btn btn-sm btn-info hider" data-toggle='collapse' data-target='<%= "#item-container-#{document.id}-#{document_index}" %>' aria-expanded='false' aria-controls='this'>
+                  <%= t('trln_argon.show.controls.hide') %> <%= t('trln_argon.show.controls.items') %> <i class="fa fa-minus-circle" aria-hidden="true"></i>
+                </a>
+
+              </div>
             </div>
 
           <% end %>
 
-        </div>
-
-
-          <% if item_data['items'].length > 10 %>
-
-            <div class="summary-toggle-bottom text-center">
-              <a class="expander btn" data-toggle='collapse' href='<%= "#item-container-#{loc_b}-#{loc_n}" %>' aria-expanded='false' aria-controls='this'>
-                <span class='hider'><%= t('trln_argon.show.controls.hide') %> <%= t('trln_argon.show.controls.items') %> <i class="fa fa-minus-circle" aria-hidden="true"></i></span>
-              </a>
-            </div>
-
-          <% end %>
+      <% # -- END items wrapper -- %>
 
       <% end %>
 

--- a/app/views/catalog/_items_section_summary.html.erb
+++ b/app/views/catalog/_items_section_summary.html.erb
@@ -1,0 +1,55 @@
+<% # --- SUMMARY --- %>
+
+<div class="row">
+
+  <div class='location-narrow-group col-md-12'>
+
+  <% if item_data['call_no'].present? %>
+    <div class='col-md-4 call-number-wrapper'>
+      <dl class="dl-horizontal">
+        <dt><span class='call-number-label label label-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
+        <dd><span class='call-number'><%= item_data['call_no'] %></span></dd>
+      </dl>
+    </div>
+  <% end %>
+
+  <% if item_data['summary'].present? %>
+
+      <div class='col-sm-8 summary-wrapper'>
+        <dl class="dl-horizontal" id="item-summary-<%= loc_b %>-<%= loc_n %>-<%= document.id %>">
+          <dt><span class='summary-label label label-info'><%= t('trln_argon.show.label.summary') %></span></dt>
+          <dd>
+
+            <div class="summary-text-wrapper expandable-content">
+              <span class="summary-text"><%= item_data['summary'].gsub(' ', '&nbsp;').html_safe %></span>
+            </div>
+
+            <div class="expandable-content-controls">
+              <span class='show-control more'><a href="javascript:void(0);" class="btn btn-show"><%= t('trln_argon.show.controls.show_more') %> <i class="fa fa-chevron-circle-down" aria-hidden="true"></i></a></span>
+              <span class='show-control less'><a href="#item-summary-<%= loc_b %>-<%= loc_n %>-<%= document.id %>" class="btn btn-hide"><%= t('trln_argon.show.controls.show_less') %> <i class="fa fa-chevron-circle-up" aria-hidden="true"></i></a></span>
+            </div>
+
+          </dd>
+
+        </dl>
+
+      </div>
+
+  <% end %>
+
+  <% if has_holding_notes %>
+
+    <div class='holding-note col-md-12'>
+
+      <dl class="dl-horizontal">
+        <dt><span class='holding-note-label label label-info'><%= t('trln_argon.show.label.holding_note') %></span></dt>
+        <dd><%= [*item_data['notes']].join("; "); %></dd>
+      </dl>
+
+    </div>
+
+  <% end %>
+
+  </div>
+
+</div>

--- a/config/initializers/trln_argon.rb
+++ b/config/initializers/trln_argon.rb
@@ -13,6 +13,8 @@ TrlnArgon::Engine.configure do |config|
   apply_local_configuration(config, 'feedback_url')
   apply_local_configuration(config, 'sort_order_in_holding_list')
   apply_local_configuration(config, 'number_of_location_facets')
+  apply_local_configuration(config, 'number_of_items_index_view')
+  apply_local_configuration(config, 'number_of_items_show_view')
 
   config.code_mappings = {
     git_url: 'https://github.com/trln/argon_code_mappings',

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -173,6 +173,7 @@ en:
 
             controls:
                 show: "show"
+                all: "all"
                 hide: "hide"
                 items: "items"
                 show_more: "show more"

--- a/lib/generators/trln_argon/templates/local_env.yml
+++ b/lib/generators/trln_argon/templates/local_env.yml
@@ -9,3 +9,5 @@ FEEDBACK_URL: ''
 #Define the order of institutions in holding list. Your institution should go first.
 SORT_ORDER_IN_HOLDING_LIST: 'unc, duke, ncsu, nccu, trln'
 NUMBER_OF_LOCATION_FACETS: '10'
+NUMBER_OF_ITEMS_INDEX_VIEW: '3'
+NUMBER_OF_ITEMS_SHOW_VIEW: '6'

--- a/lib/trln_argon/engine.rb
+++ b/lib/trln_argon/engine.rb
@@ -35,7 +35,9 @@ module TrlnArgon
                     :contact_url,
                     :feedback_url,
                     :sort_order_in_holding_list,
-                    :number_of_location_facets
+                    :number_of_location_facets,
+                    :number_of_items_index_view,
+                    :number_of_items_show_view
 
       # rubocop:disable MethodLength
       def initialize
@@ -55,6 +57,8 @@ module TrlnArgon
         @feedback_url = ''
         @sort_order_in_holding_list = 'unc, duke, ncsu, nccu, trln'
         @number_of_location_facets = '10'
+        @number_of_items_index_view = '3'
+        @number_of_items_show_view = '6'
       end
 
       private

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.5.32'.freeze
+  VERSION = '0.5.33'.freeze
 end

--- a/lib/trln_argon/view_helpers/trln_argon_helper.rb
+++ b/lib/trln_argon/view_helpers/trln_argon_helper.rb
@@ -86,16 +86,11 @@ module TrlnArgon
       end
 
       def call_number_display(item)
-        r = call_number_fetch(item)
-        return '' if r == ''
+        return '' if item.nil? || item.empty? || !item.respond_to?(:fetch)
+        r = item.fetch('call_no', '')
         r << " #{item['vol']}" if item.key?('vol')
         r << " #{item['copy_no']}" if item.key?('copy_no')
         r
-      end
-
-      def call_number_fetch(item)
-        return '' if item.nil? || item.empty? || !item.respond_to?(:fetch)
-        item.fetch('call_no', '')
       end
 
       def item_notes_display(item)

--- a/spec/lib/trln_argon/engine_spec.rb
+++ b/spec/lib/trln_argon/engine_spec.rb
@@ -38,6 +38,14 @@ describe TrlnArgon::Engine do
     it 'sets number of location facets' do
       expect(config.number_of_location_facets).to eq('10')
     end
+
+    it 'sets number of items in index view' do
+      expect(config.number_of_items_index_view).to eq('3')
+    end
+
+    it 'sets number of items in show view' do
+      expect(config.number_of_items_show_view).to eq('6')
+    end
   end
 
   describe 'it should accept custom configuration values' do
@@ -88,6 +96,14 @@ describe TrlnArgon::Engine do
 
     it 'sets number of location facets' do
       expect(config.number_of_location_facets).to eq('10')
+    end
+
+    it 'sets number of items in index view' do
+      expect(config.number_of_items_index_view).to eq('3')
+    end
+
+    it 'sets number of items in show view' do
+      expect(config.number_of_items_show_view).to eq('6')
     end
   end
 end


### PR DESCRIPTION
- presence of summary no longer required to show/hide long lists of items
- can configure number of initially-displayed items for index and show views -- defaults to 3/6
- adds 'misc' color to availability status
- rolls back changes from https://github.com/trln/trln_argon/releases/tag/0.5.32 -- I noticed this created more problems than it solved