### PR TITLE
add rake task to reload code mappings while application is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Running a Rails application in production mode has a number of benefits, one
 being that the application is not constantly checking to see if parts of it
 have changed, that it has less verbose logging, etc.  If you are demoing the
 project, you might want to use this mode, but note this is not a guide to
-putting this engine into production, because it's not really secure long-term.
+putting this engine into production, because the illustrated process is
+not really secure long-term.
+
 So do this at your own risk!
 
 1. Create a secret key to use
@@ -86,6 +88,26 @@ Alternately, if you don't want to fiddle with Apache or NGINX,
 
         $ caddy
 
+## Code Mappings
+
+Code mappings are handled by synchronizing a directory on the local filesystem
+with the [argon_code_mappings](https://github.com/trln/argon_code_mappings)
+repository.  By default, the repository will be checked out to the directory
+`argon_mappings` under `config/mappings/` under the Rails root (.e.g.
+`config/mappings/argon_mappings`).  If you don't like the idea of having
+another git repository inside what might be the git repository containing your
+application, you can set
+`ARGON_CODE_MAPPINGS_DIR` (in `local_env.yml`, see below) to an appropriate value.
+
+The lookups generated from these files are loaded at application startup and reloaded every 24 hours (which allows your application to pick up changes coming in from other institutions without you having to intervene), but if you have made a locally important change and you want to reload the mappings immediately, you can execute the rake task `trln_argon:reload_code_mappings`.  This will sync your local copy with the upstream repository, and un-cache the lookups generated from the files in the repository, meaning your changes will be visible immediately in the running application.
+
+    $ RAILS_ENV=production bundle exec rake trln_argon:reload_code_mappings
+
+Note: when running in 'development' environment, Rails caching is a no-op, so
+any changes you make to the local copy of your repository (by editing the files
+in the working tree or by pulling changes from github) should be viewable
+immediately in this environment.
+
 ## About the `trln_argon:install` generator task
 
 You can see what the generator does in this file: [install_generator.rb](https://github.com/trln/trln_argon/blob/master/lib/generators/trln_argon/install_generator.rb)
@@ -107,6 +129,8 @@ You will need to change settings in this file so that features like record rollu
 SOLR_URL: http://127.0.0.1:8983/solr/trln
 LOCAL_INSTITUTION_CODE: unc
 APPLICATION_NAME: TRLN Argon
+# Where the argon_code_mappings git repo is checked out.
+ARGON_CODE_MAPPINGS_DIR: #{Rails.root.join('config', 'mappings')
 REFWORKS_URL: "http://www.refworks.com.libproxy.lib.unc.edu/express/ExpressImport.asp?vendor=SearchUNC&filter=RIS%20Format&encoding=65001&url="
 ROOT_URL: 'https://discovery.trln.org'
 ARTICLE_SEARCH_URL: 'http://libproxy.lib.unc.edu/login?url=http://unc.summon.serialssolutions.com/search?s.secure=f&s.ho=t&s.role=authenticated&s.ps=20&s.q='
@@ -117,6 +141,10 @@ SORT_ORDER_IN_HOLDING_LIST: 'unc, duke, ncsu, nccu, trln'
 NUMBER_OF_LOCATION_FACETS: '10'
 NUMBER_OF_ITEMS_INDEX_VIEW: '3'
 NUMBER_OF_ITEMS_SHOW_VIEW: '6'
+# this entry need not be present, but this shows the default
+# value; a git repository containing the mappings is checked
+# out to the directory
+ARGON_CODE_MAPPINGS_DIR: #{File.join(Rails.root, 'config', 'mappings')
 ```
 
 ### Changing Styles

--- a/config/initializers/trln_argon.rb
+++ b/config/initializers/trln_argon.rb
@@ -15,13 +15,18 @@ TrlnArgon::Engine.configure do |config|
   apply_local_configuration(config, 'number_of_location_facets')
   apply_local_configuration(config, 'number_of_items_index_view')
   apply_local_configuration(config, 'number_of_items_show_view')
+  apply_local_configuration(config, 'argon_code_mappings_dir')
 
   config.code_mappings = {
     git_url: 'https://github.com/trln/argon_code_mappings',
     git_branch: 'master'
   }
-  git_fetcher = TrlnArgon::MappingsGitFetcher.new(git_url: config.code_mappings[:git_url])
-  TrlnArgon::LookupManager.fetcher = git_fetcher
 
+  git_fetcher = TrlnArgon::MappingsGitFetcher.new(
+    git_url: config.code_mappings[:git_url],
+    repo_base: config.argon_code_mappings_dir
+  )
+  TrlnArgon::LookupManager.fetcher = git_fetcher
+  # do a lookup so the mappings are initialized.
   TrlnArgon::LookupManager.instance.map('ncsu.library.DHHILL')
 end

--- a/lib/tasks/trln_argon_tasks.rake
+++ b/lib/tasks/trln_argon_tasks.rake
@@ -5,6 +5,14 @@ task :ci do
 end
 
 namespace :trln_argon do
+  desc 'Refreshes code mappings from github and reloads the cache'
+  task(reload_code_mappings: :environment) do
+    require 'trln_argon/mappings'
+    puts 'Expiring cached lookups'
+    TrlnArgon::LookupManager.instance.reload
+    puts 'Reloaded mappings from github'
+  end
+
   namespace :solr do
     require 'trln_argon/field.rb'
     require 'trln_argon/fields.rb'
@@ -35,6 +43,7 @@ namespace :trln_argon do
       puts @defined_fields
     end
 
+    desc 'reload mapping codes (locations)'
     desc 'get all fields defined in TRLN Argon'
     task defined_fields: :environment do
       include TrlnArgon::Fields

--- a/lib/trln_argon/engine.rb
+++ b/lib/trln_argon/engine.rb
@@ -27,6 +27,7 @@ module TrlnArgon
     class Configuration
       attr_accessor :local_institution_code,
                     :application_name,
+                    :argon_code_mappings_dir,
                     :solr_fields,
                     :code_mappings,
                     :refworks_url,
@@ -43,6 +44,7 @@ module TrlnArgon
       def initialize
         @local_institution_code        = 'unc'
         @application_name              = 'TRLN Argon'
+        @argon_code_mappings_dir       = Rails.root.join('config', 'mappings')
         @solr_fields =
           field_constants(default_fields.merge(override_fields).deep_symbolize_keys)
         @refworks_url =
@@ -60,6 +62,7 @@ module TrlnArgon
         @number_of_items_index_view = '3'
         @number_of_items_show_view = '6'
       end
+      # rubocop:enable MethodLength
 
       private
 

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.6.5'.freeze
+  VERSION = '0.6.6'.freeze
 end

--- a/spec/lib/trln_argon/lookups_spec.rb
+++ b/spec/lib/trln_argon/lookups_spec.rb
@@ -15,10 +15,6 @@ describe TrlnArgon::Lookups do
     expect(lookups.lookup(pathspec)).to eq('')
   end
 
-  it 'can be safely marshaled' do
-    expect(Marshal.dump(lookups)).not_to be_nil
-  end
-
   it 'correctly masks faceted locations' do
     lib1_facet = lookups.lookup('test1.facet.lib1')
     expect(lib1_facet).to eq('Facet lib1')
@@ -27,5 +23,11 @@ describe TrlnArgon::Lookups do
   it 'correctly falls back when no facet value mapped' do
     lib2_facet = lookups.lookup('test2.facet.lib2')
     expect(lib2_facet).to eq(lookups.lookup('test2.loc_b.lib2'))
+  end
+
+  context '#mappings' do
+    it 'can be safely marshaled' do
+      expect(Marshal.dump(lookups.mappings)).not_to be_nil
+    end
   end
 end


### PR DESCRIPTION
This required reworking the cache mechanism as well.
May be a small speed boost as new implementation does not require deserializing a marshalled object each time a lookup is performed.