### PR TITLE
Support for URL template parameter substitution.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ Metrics/AbcSize:
   Exclude:
     - 'lib/trln_argon/view_helpers/catalog_helper_behavior.rb'
     - 'lib/trln_argon/view_helpers/hierarchy_helper.rb'
+    - 'lib/trln_argon/mappings.rb'
 
 Metrics/BlockLength:
   Exclude:

--- a/lib/trln_argon/mappings.rb
+++ b/lib/trln_argon/mappings.rb
@@ -50,7 +50,8 @@ module TrlnArgon
 
     FILENAMES = {
       location_holdings: 'location_item_holdings.json',
-      location_facet: 'location_facet.json'
+      location_facet: 'location_facet.json',
+      url_template: 'url_template.json'
     }.freeze
 
     def initialize(base = '.')
@@ -90,10 +91,13 @@ module TrlnArgon
         parse_holdings!(lhf, inst_mappings)
         lff = File.join(path, FILENAMES[:location_facet])
         facets = read_json(lff)
+        urltf = File.join(path, FILENAMES[:url_template])
+        url_template = read_json(urltf)
         inst_mappings['loc_b'].each do |k, v|
           facets[k] ||= v
         end
         inst_mappings['facet'] = facets
+        inst_mappings['url_template'] = url_template
       end
       mappings
     end

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.6.5'.freeze
+  VERSION = '0.6.6'.freeze
 end

--- a/spec/lib/trln_argon/solr_document_spec.rb
+++ b/spec/lib/trln_argon/solr_document_spec.rb
@@ -42,13 +42,14 @@ describe TrlnArgon::SolrDocument do
                   '{"href":"http://www.law.duke.edu/journals/lcp/",'\
                   '"type":"other",'\
                   '"text":"Law and contemporary problems, v. 63, no. 1-2"}',
-                  '{"href":"http://www.law.duke.edu/journals/lcp/",'\
+                  '{"href":"{proxyPrefix}http://www.law.duke.edu/journals/lcp/",'\
                   '"type":"other",'\
                   '"text":"Law and contemporary problems, v. 63, no. 1-2"}']
         )
       end
 
-      it 'deserializes each of the url entries' do
+      it 'deserializes each of the url entries and maps any templated URL segments' do
+        allow(solr_document).to receive(:url_template_mapper).and_return('http://libproxy.lib.unc.edu/login?url=')
         expect(solr_document.urls).to(
           eq([{ href: 'http://www.law.duke.edu/journals/lcp/',
                 type: 'other',
@@ -56,7 +57,7 @@ describe TrlnArgon::SolrDocument do
               { href: 'http://www.law.duke.edu/journals/lcp/',
                 type: 'other',
                 text: 'Law and contemporary problems, v. 63, no. 1-2' },
-              { href: 'http://www.law.duke.edu/journals/lcp/',
+              { href: 'http://libproxy.lib.unc.edu/login?url=http://www.law.duke.edu/journals/lcp/',
                 type: 'other',
                 text: 'Law and contemporary problems, v. 63, no. 1-2' }])
         )


### PR DESCRIPTION
- Looks for parameter names contained by {} in stored URLs (e.g. {proxyPrefix}http://www.law.duke.edu/journals/lcp/).
- Replaces the parameter with the value mapped to the key in argon_code_mappings ( argon_code_mappings/duke/url_template.json)
`{
  "proxyPrefix" : "http://proxy.lib.duke.edu/login?url="
}`
- This supports generating institution specific URLs for shared records. See URL documentation: https://github.com/trln/data-documentation/blob/master/argot/spec_docs/url.adoc#examples