### PR TITLE
remove syntax error from mappings fetch freshness check

### DIFF
--- a/lib/trln_argon/mappings.rb
+++ b/lib/trln_argon/mappings.rb
@@ -48,7 +48,7 @@ module TrlnArgon
         if File.exist?(head_fetch_file)
           # this method might get called in a loop when, e.g. creating
           # an engine_cart instance, so we need a very short term cache.
-          do_pull = File.stat(head_fetch_file).mtime > (Time.now = 2.minutes)
+          do_pull = File.stat(head_fetch_file).mtime > (Time.now - 2.minutes)
         end
 
         if do_pull

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.6.8'.freeze
+  VERSION = '0.6.9'.freeze
 end


### PR DESCRIPTION
Syntax error crept into 0.6.6, triggered only when starting a new trln_argon-based environment.