### PR TITLE
widen the primary link class from md-7 to sm-12.

### DIFF
--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.7.4'.freeze
+  VERSION = '0.7.5'.freeze
 end

--- a/lib/trln_argon/view_helpers/link_helper.rb
+++ b/lib/trln_argon/view_helpers/link_helper.rb
@@ -2,7 +2,7 @@ module TrlnArgon
   module ViewHelpers
     module LinkHelper
       def primary_link_class
-        'col-md-7 primary-url'
+        'col-sm-12 primary-url'
       end
 
       # Other and related links


### PR DESCRIPTION
We noticed that when adding text to the right of the primary link that the container is needlessly set at col-md-7.  As far as I know nothing will ever be displayed to the right of that div.

old behavior: ![old md 7](https://user-images.githubusercontent.com/3514165/49098366-b5fcc000-f23c-11e8-9782-6b22739e35ef.png)

new behavior: ![new sm 12](https://user-images.githubusercontent.com/3514165/49098374-b8f7b080-f23c-11e8-9384-fc82c67d812f.png)
