### PR TITLE
fix work_entry linking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,37 @@ else
   end
 end
 # END ENGINE_CART BLOCK
+# BEGIN ENGINE_CART BLOCK
+# engine_cart: 2.0.1
+# engine_cart stanza: 0.10.0
+# the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
+file = File.expand_path('Gemfile', ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path('.internal_test_app', File.dirname(__FILE__)))
+if File.exist?(file)
+  begin
+    eval_gemfile file
+  rescue Bundler::GemfileError => e
+    Bundler.ui.warn '[EngineCart] Skipping Rails application dependencies:'
+    Bundler.ui.warn e.message
+  end
+else
+  Bundler.ui.warn "[EngineCart] Unable to find test application dependencies in #{file}, using placeholder dependencies"
+
+  if ENV['RAILS_VERSION']
+    if ENV['RAILS_VERSION'] == 'edge'
+      gem 'rails', github: 'rails/rails'
+      ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
+    else
+      gem 'rails', ENV['RAILS_VERSION']
+    end
+  end
+
+  case ENV['RAILS_VERSION']
+  when /^4.2/
+    gem 'responders', '~> 2.0'
+    gem 'sass-rails', '>= 5.0'
+    gem 'coffee-rails', '~> 4.1.0'
+  when /^4.[01]/
+    gem 'sass-rails', '< 5.0'
+  end
+end
+# END ENGINE_CART BLOCK

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ bootstrap a Blacklight catalog for the TRLN shared catalog index.
 
 We use [Engine Cart](https://github.com/cbeer/engine_cart) to run a development instance.  To run with `engine_cart`, clone this repository and change into the directory, then run:
 
-       $ bundle exec rake engine_cart:prepare
+       $ bundle install
+	   $ bundle exec rake engine_cart:prepare
        $ bundle exec rake engine_cart:server
        $ # if you already have something on port 3000 and want to use a different port
-    $ bundle exec rake engine_cart:server['-p 3001']
+       $ bundle exec rake engine_cart:server['-p 3001']
 
 The TRLN Argon Blacklight catalog should now be available at [http://localhost:3000](http://localhost:3000) (or a different port if you used the second form).
 

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -483,6 +483,17 @@ module TrlnArgon
           field.include_in_advanced_search = false
         end
 
+        config.add_search_field('work_entry') do |field|
+          field.label = 'Work'
+          field.def_type = 'edismax'
+          field.solr_local_parameters = {
+            qf: '$work_entry_qf',
+            pf: '$work_entry_pf'
+          }
+          field.if = false
+          field.include_in_advanced_search = false
+        end
+
         # "sort results by" select (pulldown)
         # label in pulldown is followed by the name of the SOLR field to sort by and
         # whether the sort is ascending or descending (it must be asc or desc

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.8.1'.freeze
+  VERSION = '0.8.2'.freeze
 end

--- a/lib/trln_argon/view_helpers/work_entry_helper.rb
+++ b/lib/trln_argon/view_helpers/work_entry_helper.rb
@@ -35,7 +35,7 @@ module TrlnArgon
 
       def work_entry_author(work)
         return if work[:author].empty?
-        search_params = { search_field: 'author', q: work[:author] }
+        search_params = { search_field: 'author', q: "\"#{work[:author]}\"" }
         link_to(work[:author],
                 search_action_url(search_params),
                 class: 'progressive-link')
@@ -84,7 +84,12 @@ module TrlnArgon
       end
 
       def work_entry_link_url(params_segments)
-        search_action_url(params_segments.merge(op: 'AND', search_field: 'advanced'))
+        query_values = []
+        query_values << params_segments[:author]
+        query_values << params_segments[:title]
+        query_values = query_values.compact
+        search_action_url({ search_field: 'work_entry', q: "\"#{query_values.join(' ')}\"" })
+        #search_action_url(params_segments.merge(op: 'AND', search_field: 'advanced'))
       end
     end
   end

--- a/lib/trln_argon/view_helpers/work_entry_helper.rb
+++ b/lib/trln_argon/view_helpers/work_entry_helper.rb
@@ -88,7 +88,7 @@ module TrlnArgon
         query_values << params_segments[:author]
         query_values << params_segments[:title]
         query_values = query_values.compact
-        search_action_url(search_field: 'work_entry', q: "\"#{query_values.join(' ')}\"" )
+        search_action_url(search_field: 'work_entry', q: "\"#{query_values.join(' ')}\"")
       end
     end
   end

--- a/lib/trln_argon/view_helpers/work_entry_helper.rb
+++ b/lib/trln_argon/view_helpers/work_entry_helper.rb
@@ -88,8 +88,7 @@ module TrlnArgon
         query_values << params_segments[:author]
         query_values << params_segments[:title]
         query_values = query_values.compact
-        search_action_url({ search_field: 'work_entry', q: "\"#{query_values.join(' ')}\"" })
-        #search_action_url(params_segments.merge(op: 'AND', search_field: 'advanced'))
+        search_action_url(search_field: 'work_entry', q: "\"#{query_values.join(' ')}\"" )
       end
     end
   end


### PR DESCRIPTION
Draft release: https://github.com/trln/trln_argon/releases/edit/untagged-043be4eecd4160dee7a9

Hyperlink queries on title segments in work_entry-type data now search the work_entry search_field instead of doing an advanced search on author AND title.

Running `rake spec`, everything passes. 

I did NOT manually edit the Gemfile and am not sure how to fix that. It seems to have been updated when I followed the steps to set up for local development (?)
