### PR TITLE
bug fix for bootstrap-select in masthead:

### DIFF
--- a/app/assets/javascripts/trln_argon/force_bootstrap-select_render.js
+++ b/app/assets/javascripts/trln_argon/force_bootstrap-select_render.js
@@ -1,0 +1,2 @@
+// avoid flashing and/or slow loading of bootstrap-select in masthead search
+$(function(){ $(".selectpicker").selectpicker('render'); })

--- a/app/assets/javascripts/trln_argon/trln_argon.js
+++ b/app/assets/javascripts/trln_argon/trln_argon.js
@@ -14,3 +14,4 @@
 //= require trln_argon/google_books_preview.js.erb
 //= require trln_argon/hathitrust_links
 //= require trln_argon/skiplink.js
+//= require trln_argon/force_bootstrap-select_render.js

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.8.6.1'.freeze
+  VERSION = '0.8.7'.freeze
 end


### PR DESCRIPTION
- lets the fancy select list get rendered without waiting for everything else to finish first
- avoids flash of missing select list