### PR TITLE
Add Url Notes to primary links

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -1168,12 +1168,16 @@ h1, h2, h3, h4, h5 {
     margin-right: 1em;*/
 
   }
-
+  .url-note-wrapper {
+    margin-top:10px;
+  }
+  
   .call-number-label,
   .status-label,
   .summary-label,
   .item-note-label,
-  .holding-note-label {
+  .holding-note-label,
+  .url-note-label {
     background: #e5e5e5;
     color: #444;
     border: 1px solid #ddd;

--- a/app/views/catalog/_finding_aid_links.html.erb
+++ b/app/views/catalog/_finding_aid_links.html.erb
@@ -2,7 +2,10 @@
   <div class="<%= primary_link_class %>">
     <ul>
     <% document.findingaid_urls.each do |url| %>
-      <li><%= link_to_finding_aid(url) %></li>
+      <li>
+        <%= link_to_finding_aid(url) %>
+        <%= render partial: "url_note", locals: { url_hash: url } %>
+      </li>
     <% end %>
     </ul>
   </div>

--- a/app/views/catalog/_fulltext_links.html.erb
+++ b/app/views/catalog/_fulltext_links.html.erb
@@ -3,7 +3,10 @@
     <div class="<%= primary_link_class %>">
       <ul>
       <% document.fulltext_urls.each do |url| %>
-        <li><%= link_to_fulltext_url(url) %></li>
+        <li>
+          <%= link_to_fulltext_url(url) %>
+          <%= render partial: "url_note", locals: { url_hash: url } %>
+        </li>
       <% end %>
       </ul>
     </div>
@@ -11,7 +14,10 @@
     <div class="primary-url <%= primary_link_class %>">
       <ul>
       <% document.shared_fulltext_urls.each do |url| %>
-        <li><%= link_to_fulltext_url(url) %></li>
+        <li>
+          <%= link_to_fulltext_url(url) %>
+          <%= render partial: "url_note", locals: { url_hash: url } %>
+        </li>
       <% end %>
       </ul>
     </div>

--- a/app/views/catalog/_open_access_links.html.erb
+++ b/app/views/catalog/_open_access_links.html.erb
@@ -5,6 +5,7 @@
         <% next unless urls.present? %>
           <li>
             <%= link_to_open_access(urls) %>
+            <%= render partial: "url_note", locals: { url_hash: urls } %>
           </li>
       <% end %>
     </ul>

--- a/app/views/catalog/_url_note.html.erb
+++ b/app/views/catalog/_url_note.html.erb
@@ -1,0 +1,8 @@
+<% if url_hash[:note].present? %>
+  <div class="<%= url_note_wrapper_class %>">
+    <dl class="dl-horizontal">
+      <dt><span class='url-note-label label label-info'><%= t('trln_argon.show.label.url_note') %></span></dt>
+      <dd><span class='url-note'><%= url_hash[:note] %></dd>
+    </dl>
+  </div>
+<% end %>

--- a/app/views/trln/_expanded_fulltext_links.html.erb
+++ b/app/views/trln/_expanded_fulltext_links.html.erb
@@ -3,9 +3,10 @@
     <ul>
       <% document.all_shared_and_local_fulltext_urls_by_inst.fetch(inst, []).to_a.each do |url| %>
         <% next unless url.present? %>
-          <li>
-            <%= link_to_expanded_fulltext_url(url, inst) %>
-          </li>
+        <li>
+          <%= link_to_expanded_fulltext_url(url, inst) %>
+          <%= render partial: "url_note", locals: { url_hash: url } %>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/app/views/trln/_open_access_links.html.erb
+++ b/app/views/trln/_open_access_links.html.erb
@@ -5,6 +5,7 @@
         <% next unless url.present? %>
           <li>
             <%= expanded_link_to_open_access(url) %>
+            <%= render partial: "url_note", locals: { url_hash: url } %>
           </li>
       <% end %>
     </ul>

--- a/app/views/trln/_url_note.html.erb
+++ b/app/views/trln/_url_note.html.erb
@@ -1,8 +1,0 @@
-<% if url_hash[:note].present? %>
-  <div class="<%= url_note_wrapper_class %>">
-    <dl class="dl-horizontal">
-      <dt><span class='url-note-label label label-info'><%= t('trln_argon.show.label.url_note') %></span></dt>
-      <dd><span class='url-note'><%= url_hash[:note] %></dd>
-    </dl>
-  </div>
-<% end %>

--- a/app/views/trln/_url_note.html.erb
+++ b/app/views/trln/_url_note.html.erb
@@ -1,0 +1,8 @@
+<% if url_hash[:note].present? %>
+  <div class="<%= url_note_wrapper_class %>">
+    <dl class="dl-horizontal">
+      <dt><span class='url-note-label label label-info'><%= t('trln_argon.show.label.url_note') %></span></dt>
+      <dd><span class='url-note'><%= url_hash[:note] %></dd>
+    </dl>
+  </div>
+<% end %>

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -177,6 +177,7 @@ en:
                 status: "Status"
                 item_note: "Note"
                 holding_note: "Note"
+                url_note: "Note"
 
             controls:
                 show: "show"

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '0.8.10'.freeze
+  VERSION = '0.8.11'.freeze
 end

--- a/lib/trln_argon/view_helpers/items_section_helper.rb
+++ b/lib/trln_argon/view_helpers/items_section_helper.rb
@@ -38,7 +38,7 @@ module TrlnArgon
       end
 
       def url_note_wrapper_class
-        'col-sm-12 url-note-wrapper'
+        'url-note-wrapper'
       end
 
       def item_availability_display(item)

--- a/lib/trln_argon/view_helpers/items_section_helper.rb
+++ b/lib/trln_argon/view_helpers/items_section_helper.rb
@@ -37,6 +37,10 @@ module TrlnArgon
         'holding-note col-md-12'
       end
 
+      def url_note_wrapper_class
+        'col-sm-12 url-note-wrapper'
+      end
+
       def item_availability_display(item)
         case item['status']
         when /^available/i

--- a/spec/lib/trln_argon/solr_document_spec.rb
+++ b/spec/lib/trln_argon/solr_document_spec.rb
@@ -284,6 +284,23 @@ describe TrlnArgon::SolrDocument do
       end
     end
 
+    context 'field contains url note' do
+      let(:solr_document) do
+        SolrDocumentTestClass.new(
+          id: 'NCSU1234567',
+          url_a: ['{"href":"http://purl.access.gpo.gov/GPO/LPS606","type":"fulltext",'\
+                  '"note":"This is an 856$3 note."}']
+        )
+      end
+
+      it 'deserializes the url entry and includes the note.' do
+        expect(solr_document.urls).to(
+          eq([{ href: 'http://purl.access.gpo.gov/GPO/LPS606', type: 'fulltext',
+                text: '', note: 'This is an 856$3 note.' }])
+        )
+      end
+    end
+
     context 'field contains some values not parsable as JSON' do
       let(:solr_document) do
         SolrDocumentTestClass.new(

--- a/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
@@ -263,6 +263,14 @@ describe TrlnArgonHelper, type: :helper do
     end
   end
 
+  describe '#url_note_wrapper_class' do
+    it 'returns the HTML class attribute values' do
+      expect(helper.url_note_wrapper_class).to(
+        eq('col-sm-12 url-note-wrapper')
+      )
+    end
+  end
+
   describe '#item_availability_display' do
     context 'item is available' do
       let(:item) { { 'status' => 'Available' } }

--- a/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
@@ -266,7 +266,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#url_note_wrapper_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.url_note_wrapper_class).to(
-        eq('col-sm-12 url-note-wrapper')
+        eq('url-note-wrapper')
       )
     end
   end


### PR DESCRIPTION
 - Adds url notes partial templates to local and expanded views for different link types (fulltext, expanded_fulltext, open_access, hathitrust).

Recent changes to marc-to-argot concatenate any 856$3$z fields to url[:note] string.  Individual institutions can choose to override these partial templates for the local contexts.

Please let me know if I should reorganize any of this or add any more tests.