### PR TITLE
Rescue failed advanced search query parse.

### DIFF
--- a/config/initializers/parsing_nesting_parser.rb
+++ b/config/initializers/parsing_nesting_parser.rb
@@ -1,0 +1,21 @@
+require 'parsing_nesting/tree'
+
+# This patches BL Advanced Search to rescue from a failed query parse.
+# For now, when this happens, skip the parse, log the error, and continue.
+# The likely result is No Results Found, which seems better than an error.
+module BlacklightAdvancedSearch
+  module ParsingNestingParser
+    def process_query(_params, config)
+      queries = keyword_queries.map do |field, query|
+        begin
+          ParsingNesting::Tree.parse(query, config.advanced_search[:query_parser])
+                              .to_query(local_param_hash(field, config))
+        rescue Parslet::ParseFailed => e
+          Rails.logger.warn { "failed to parse the advanced search query (#{query}): #{e.message}" }
+          next
+        end
+      end
+      queries.join(" #{keyword_op} ")
+    end
+  end
+end

--- a/lib/trln_argon/solr_document/urls.rb
+++ b/lib/trln_argon/solr_document/urls.rb
@@ -85,7 +85,8 @@ module TrlnArgon
       def url_has_variables?(url)
         Addressable::Template.new(url).variables.any?
       rescue RegexpError => e
-        Rails.logger.error { "#{e.message} #{e.backtrace.join("\n")}" }
+        Rails.logger.warn('unable to parse URL template for '\
+                          "#{fetch('id', 'unknown document')}: #{e}")
         false
       end
 

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.0.5'.freeze
 end


### PR DESCRIPTION
Also, modify the message for failed template URL parse.