### PR TITLE
be more selective showing google books previews

### DIFF
--- a/app/assets/javascripts/trln_argon/google_books_preview.js.erb
+++ b/app/assets/javascripts/trln_argon/google_books_preview.js.erb
@@ -1,25 +1,50 @@
 Blacklight.onLoad(function() {
-  $(window).load(function() {
-      var isbn = $('#google-books').data('isbn');
-      if (isbn) {
-        if (isbn.length > 0) {
-            for (i = 0; i < isbn.length; i++) {
-                $.ajax({
-                    url:'https://www.googleapis.com/books/v1/volumes?q=isbn:' + isbn[i],
-                    success: function(data){
-                        if (data.totalItems > 0) {
-                            $('#google-books-preview-image').each(function () {
-                                if (this.src.length == 0) {
-                                    $('#google-books-preview-image').attr({ src: "<%= asset_path('trln_argon/google_books_preview.png') %>" });
-                                    $("#google-books-preview-image").after('<a href=' + data.items[0].volumeInfo.previewLink +
-                                        ' target="_blank"> Preview this title via Google Book Search </a>');
-                                }
-                            });
+    $(window).load(function() {
+        var previewAvailable = function (item) {
+            try {
+                return $.inArray(item.accessInfo.viewability, ['PARTIAL', 'ALL_PAGES']) >= 0;
+            } catch(e) {
+            }
+            return false;
+        };
+
+        var getPreviewLink = function(data) {
+            if ( data.items && data.items.length > 0 ) {
+                try {
+                    for(var i=0, n=data.items.length; i<n; i++) {
+                        var item = data.items[i];
+                        if ( previewAvailable(item) ) {
+                            return item.volumeInfo.previewLink;
                         }
                     }
-                });
+                } catch(e) {
+                    console.info("Unable to determine google books preview link", e);
+                }
             }
-        }
+            return false;
+        };
+
+      var isbn = $('#google-books').data('isbn');
+      if (isbn) {
+        for (i = 0; i < isbn.length; i++) {
+            $.ajax({
+                url:'https://www.googleapis.com/books/v1/volumes?q=isbn:' + isbn[i],
+                success: function(data) {
+                    var link = getPreviewLink(data);
+                    if (! link ) {
+                        return;
+                    }
+                    $('#google-books-preview-image').each(function () {
+                        if (this.src.length == 0) {
+                            $('#google-books-preview-image').attr({ src: "<%= asset_path('trln_argon/google_books_preview.png') %>" });
+                            $("#google-books-preview-image").after(
+                                '<a href=' + link +
+                                ' target="_blank"> Preview this title via Google Book Search </a>');
+                         }
+                    });
+                }
+            });
+         }
       }
   });
 });

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '1.0.8'.freeze
+  VERSION = '1.0.9'.freeze
 end

--- a/trln_argon.gemspec
+++ b/trln_argon.gemspec
@@ -33,12 +33,15 @@ Gem::Specification.new do |s|
   s.add_dependency 'rsolr', '>= 1.0', '< 3'
   s.add_dependency 'addressable', '~> 2.5'
 
+  # no version specified for sqlite3 because engine_cart 2.2
+  # will otherwise use an incompatible version when generating
+  # the internal rails app (rails 5.2.3 required for sqlite3 1.4.0)
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails', '~> 3.5'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'rubocop', '~> 0.49.1'
   s.add_development_dependency 'rubocop-rspec'
-  s.add_development_dependency 'engine_cart', '~> 2.0.1'
+  s.add_development_dependency 'engine_cart', '~> 2.2'
   s.add_development_dependency 'better_errors', '~> 2.1.1'
   s.add_development_dependency 'binding_of_caller'
 end


### PR DESCRIPTION
Check to see whether partial or full access is allowed before showing a google books preview link.  GBAPI  docs (https://developers.google.com/books/docs/v1/reference/volumes) suggest that looking at `accessInfo.viewability` will tell us how much content is available.

Example where preview link is shown (v1.0.8) and no preview is available: https://discovery.trln.org/catalog/NCSU1988228 (viewability = 'NO_PAGES')

Example where preview link is shown (v1.0.8) and preview is available: https://discovery.trln.org//catalog/NCSU4440439; in this case, item.accessInfo.viewability (viewability = PARTIAL)
