### PR TITLE
Allows for multiple holdings entries per broad and narrow location.

### DIFF
--- a/app/assets/javascripts/trln_argon/expand_contract.js
+++ b/app/assets/javascripts/trln_argon/expand_contract.js
@@ -35,7 +35,7 @@ Blacklight.onLoad(function() {
     var me = $(this);
     var parent = me.parent();
     var origHeight = me.height();
-    var contractedHeight = lineHeight(this) * 3 + 2;
+    var contractedHeight = lineHeight(this) * 6 + 4;
 
     if ( origHeight <= contractedHeight ) {
       return;

--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -1332,7 +1332,7 @@ h1, h2, h3, h4, h5 {
       width: 7em;
     }
 
-    dd { margin-left: 6.5em; }
+    dd { margin-left: 7.1em; }
 
   }
 
@@ -1653,4 +1653,33 @@ h2.local-filter-heading  {
 .skiplink {
   position: absolute;
   left: -10000px;
+}
+
+
+
+
+/* Holdings */
+
+.holdings-wrapper {
+  overflow: hidden;
+}
+
+div[aria-expanded=false] .expandable-content-controls .show-control.more {
+  display: inline;
+}
+
+div[aria-expanded=true] .expandable-content-controls .show-control.less {
+  display: inline;
+}
+
+.holdings-wrapper.contracted:after {
+  background: linear-gradient(to right, rgba(243, 243, 243, 0), rgba(237, 237, 237, 1) 50%);
+}
+
+.holdings-wrapper.contracted {
+  max-height: 90px;
+}
+
+.holdings-wrapper.contracted-ul {
+  max-height: 110px;
 }

--- a/app/models/default_local_search_builder.rb
+++ b/app/models/default_local_search_builder.rb
@@ -1,5 +1,6 @@
 class DefaultLocalSearchBuilder < SearchBuilder
-  self.default_processor_chain += %i[min_match_for_cjk
+  self.default_processor_chain += %i[wildcard_char_strip
+                                     min_match_for_cjk
                                      min_match_for_boolean
                                      show_only_local_holdings
                                      only_home_facets]

--- a/app/models/default_trln_search_builder.rb
+++ b/app/models/default_trln_search_builder.rb
@@ -1,5 +1,6 @@
 class DefaultTrlnSearchBuilder < SearchBuilder
-  self.default_processor_chain += %i[min_match_for_cjk
+  self.default_processor_chain += %i[wildcard_char_strip
+                                     min_match_for_cjk
                                      min_match_for_boolean
                                      rollup_duplicate_records
                                      only_home_facets]

--- a/app/views/catalog/_index_items_latest_received.html.erb
+++ b/app/views/catalog/_index_items_latest_received.html.erb
@@ -11,7 +11,7 @@
             	<a href="<%= lr_url %>"
             		onclick="viewin = window.open('<%= lr_url %>', 'latestreceived', 'scrollbars,menubar=1, location-1, resizable,width=750,height=600'); viewin.focus();"
     				class='latest-received-link new-window-link'
-    				target='latestreceived' onclick>View 
+    				target='latestreceived' onclick><%= t('trln_argon.latest_received.link_text') %> 
     				<i class='fa fa-external-link' aria-hidden='true'></i>
     				<span><%= t('trln_argon.show.a11y_text.latest_received') %>
  				</a>

--- a/app/views/catalog/_items_section.html.erb
+++ b/app/views/catalog/_items_section.html.erb
@@ -20,29 +20,21 @@
                                    loc_b_header_level: loc_b_header_level } %>
             </div>
 
-            <% # --- SUMMARY --- %>
+            <% # --- HOLDINGS SUMMARIES WRAPPER --- %>
 
-            <% has_holding_notes = !item_data.fetch('notes', '').blank? %>
-            <% has_summary = !item_data.fetch('summary', '').blank? %>
-
-            <% if has_summary || has_holding_notes %>
-
-              <% item_with_summary = true %>
+            <% if display_holdings_summaries?(item_data) %>
 
               <%= render partial: "items_section_summary",
                          locals: { document: document,
                                    loc_b: loc_b,
                                    loc_n: loc_n,
-                                   item_data: item_data,
-                                   has_holding_notes: has_holding_notes } %>
+                                   item_data: item_data } %>
 
             <% end %>
 
             <% # ---ITEMS WRAPPER --- %>
 
-              <div class="item-group-display <%= item_with_summary ? 'has-summary' : '' %>" id="<%= document.id %>-<%= loc_n %>-<%= document_index %>-preview">
-
-                <% items_have_notes = items_have_notes?(item_data['items']) %>
+              <div class="item-group-display <%= display_holdings_summaries?(item_data) ? 'has-summary' : '' %>" id="<%= document.id %>-<%= loc_n %>-<%= document_index %>-preview">
 
                 <% item_data['items'].first(num_display_items).each do |item| %>
 
@@ -95,7 +87,7 @@
       <% end %>
 
     <% end %>
-    <%= render partial: "items_section_extra" %>
+    <%= render partial: "items_section_extra", locals: { document: document } %>
   </div>
 
 </div>

--- a/app/views/catalog/_items_section_summary.html.erb
+++ b/app/views/catalog/_items_section_summary.html.erb
@@ -4,52 +4,71 @@
 
   <div class="<%= location_narrow_group_class %>">
 
-  <% if item_data['call_no'].present? %>
-    <div class="<%= call_number_wrapper_class %>">
-      <dl class="dl-horizontal">
-        <dt><span class='call-number-label label label-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
-        <dd><span class='call-number'><%= item_data['call_no'] %></span></dd>
-      </dl>
+    <div class="holdings-wrapper expandable-content">
+
+      <% item_data['holdings'].each do |h|  %>
+
+      <% next unless display_holdings_summary?(h) %>
+
+        <% # --- HOLDING CALL NUMBER --- %>
+
+        <% if h.fetch('call_no', '').present? %>
+
+          <div class="<%= call_number_wrapper_class %>">
+            <dl class="dl-horizontal">
+              <dt><span class='call-number-label label label-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
+              <dd><span class='call-number'><%= h['call_no'] %></span></dd>
+            </dl>
+          </div>
+
+        <% end %>
+
+        <% # --- HOLDING SUMMARY --- %>
+
+        <% if h.fetch('summary', '').present? %>
+
+          <div class="<%= holdings_summary_wrapper_class %>">
+            <dl class="dl-horizontal" id="item-summary-<%= loc_b %>-<%= loc_n %>-<%= document.id %>">
+              <dt><span class='summary-label label label-info'><%= t('trln_argon.show.label.summary') %></span></dt>
+              <dd>
+
+                <div class="summary-text-wrapper">
+                    <span class="summary-text"><%= h['summary'].gsub(' ', '&nbsp;').html_safe %></span>
+                </div>
+
+              </dd>
+            </dl>
+          </div>
+
+          <% # --- LATEST RECEIVED --- %>
+
+          <%= render partial: 'catalog/index_items_latest_received', locals: { document: @document, item_data: h } %>
+
+        <% end %>
+
+        <% # --- HOLDING NOTES --- %>
+
+        <% if h.fetch('notes', []).any? %>
+
+          <div class="<%= holdings_note_class %>">
+
+            <dl class="dl-horizontal">
+              <dt><span class='holding-note-label label label-info'><%= t('trln_argon.show.label.holding_note') %></span></dt>
+              <dd><%= [*h['notes']].join("; "); %></dd>
+            </dl>
+
+          </div>
+
+        <% end %>
+
+      <% end %>
+
     </div>
-  <% end %>
 
-  <% if item_data['summary'].present? %>
-
-      <div class="<%= holdings_summary_wrapper_class %>">
-        <dl class="dl-horizontal" id="item-summary-<%= loc_b %>-<%= loc_n %>-<%= document.id %>">
-          <dt><span class='summary-label label label-info'><%= t('trln_argon.show.label.summary') %></span></dt>
-          <dd>
-
-            <div class="summary-text-wrapper expandable-content">
-                <span class="summary-text"><%= item_data['summary'].gsub(' ', '&nbsp;').html_safe %></span>
-            </div>
-
-            <div class="expandable-content-controls">
-              <span class='show-control more'><a href="javascript:void(0);" class="btn btn-show"><%= t('trln_argon.show.controls.show_more') %> <i class="fa fa-chevron-circle-down" aria-hidden="true"></i></a></span>
-              <span class='show-control less'><a href="#item-summary-<%= loc_b %>-<%= loc_n %>-<%= document.id %>" class="btn btn-hide"><%= t('trln_argon.show.controls.show_less') %> <i class="fa fa-chevron-circle-up" aria-hidden="true"></i></a></span>
-            </div>
-
-          </dd>
-
-
-        </dl>
-      </div>
-      <%= render partial: 'catalog/index_items_latest_received', locals: { document: @document, item_data: item_data } %>
-
-  <% end %>
-
-  <% if has_holding_notes %>
-
-    <div class="<%= holdings_note_class %>">
-
-      <dl class="dl-horizontal">
-        <dt><span class='holding-note-label label label-info'><%= t('trln_argon.show.label.holding_note') %></span></dt>
-        <dd><%= [*item_data['notes']].join("; "); %></dd>
-      </dl>
-
+    <div class="expandable-content-controls">
+      <span class='show-control more'><a href="javascript:void(0);" class="btn btn-show"><%= t('trln_argon.show.controls.show_more') %> <i class="fa fa-chevron-circle-down" aria-hidden="true"></i></a></span>
+      <span class='show-control less'><a href="#item-summary-<%= loc_b %>-<%= loc_n %>-<%= document.id %>" class="btn btn-hide"><%= t('trln_argon.show.controls.show_less') %> <i class="fa fa-chevron-circle-up" aria-hidden="true"></i></a></span>
     </div>
-
-  <% end %>
 
   </div>
 

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -192,6 +192,9 @@ en:
                 show_less: "show less"
                 details: "Details"
 
+        latest_received:
+            link_text: "View"
+
         imprint_type:
             imprint: ""
             production: "Produced"

--- a/lib/trln_argon/argon_search_builder.rb
+++ b/lib/trln_argon/argon_search_builder.rb
@@ -3,6 +3,7 @@ require 'trln_argon/argon_search_builder/count_only'
 require 'trln_argon/argon_search_builder/home_facets'
 require 'trln_argon/argon_search_builder/local_filter'
 require 'trln_argon/argon_search_builder/min_match'
+require 'trln_argon/argon_search_builder/wildcard_char_strip'
 
 module TrlnArgon
   # Shared SearchBuilder behaviors concerning record rollup,
@@ -13,5 +14,6 @@ module TrlnArgon
     include HomeFacets
     include LocalFilter
     include MinMatch
+    include WildcardCharStrip
   end
 end

--- a/lib/trln_argon/argon_search_builder/wildcard_char_strip.rb
+++ b/lib/trln_argon/argon_search_builder/wildcard_char_strip.rb
@@ -1,0 +1,10 @@
+module TrlnArgon
+  module ArgonSearchBuilder
+    module WildcardCharStrip
+      def wildcard_char_strip(solr_parameters)
+        return unless solr_parameters[:q]
+        solr_parameters[:q] = solr_parameters[:q].delete('?')
+      end
+    end
+  end
+end

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '1.0.16'.freeze
+  VERSION = '1.1.0.pre'.freeze
 end

--- a/lib/trln_argon/view_helpers/link_helper.rb
+++ b/lib/trln_argon/view_helpers/link_helper.rb
@@ -93,7 +93,7 @@ module TrlnArgon
       def display_expanded_holdings_and_links?(document, local_doc, inst)
         document.all_shared_and_local_fulltext_urls_by_inst.fetch(inst, []).to_a.any? ||
           document.all_open_access_urls_by_inst.fetch(inst, []).to_a.any? ||
-          (local_doc.present? && !(local_doc.holdings.keys - ['ONLINE', 'DUKIR', '', nil]).empty?)
+          display_items?(document: local_doc)
       end
 
       def display_expanded_links?(document, inst)

--- a/lib/trln_argon/view_helpers/trln_argon_helper.rb
+++ b/lib/trln_argon/view_helpers/trln_argon_helper.rb
@@ -169,32 +169,6 @@ module TrlnArgon
           image_tag(url.to_s, class: 'coverImage', onerror: "this.style.display = 'none';", alt: 'cover image')
         end
       end
-
-      def holdings_have_notes?(holdings)
-        return false if holdings.nil? || holdings.empty? || !holdings.respond_to?(:fetch)
-        holdings.any? { |_loc_b, loc_narrow_map| holdings_location_has_notes?(loc_narrow_map) }
-      end
-
-      def holding_has_notes?(holding)
-        return false if holding.nil? || holding.empty? || !holding.respond_to?(:fetch)
-        holding.any? { |i| !i.fetch('notes', '').empty? }
-      end
-
-      # Tests whether a given holdings for a broad location
-      # has notes to show
-      def holdings_location_has_notes?(holdings_loc)
-        return false if holdings_loc.nil? || holdings_loc.empty?
-        holdings_loc.any? do |_loc_n, item_data|
-          items_have_notes?(item_data['items'])
-        end
-      end
-
-      # tests whether there are notes for any of the items
-      # in an array
-      def items_have_notes?(items)
-        return false if items.nil? || items.empty?
-        items.any? { |i| !i.fetch('notes', '').empty? }
-      end
     end
   end
 end

--- a/spec/fixtures/files/documents/DUKE002952265.yml
+++ b/spec/fixtures/files/documents/DUKE002952265.yml
@@ -58,7 +58,7 @@
   subject_genre_a:
   - Classification
   - Nonfiction
-  publication_year_isort_stored_single: '1986'
+  publication_year_sort: '1986'
   location_hierarchy_a:
   - duke
   - duke:dukepers

--- a/spec/fixtures/files/documents/DUKE004093564.yml
+++ b/spec/fixtures/files/documents/DUKE004093564.yml
@@ -1,0 +1,97 @@
+---
+id: DUKE004093564
+url_a:
+- '{"href":"http://purl.access.gpo.gov/GPO/LPS107796","type":"fulltext","restricted":"false"}'
+items_a:
+- '{"loc_b":"DOCS","loc_n":"PGS","cn_scheme":"","call_no":"Y 1.1/5:","type":"BOOK","item_id":"B930377","status":"Available"}'
+author_suggest:
+- United States. Congress. Senate. Committee on Homeland Security and Governmental
+  Affairs
+- United States. Congress. Senate.
+- United States. Congress. Senate.
+names_a:
+- '{"name":"United States. Congress. Senate. Committee on Homeland Security and Governmental
+  Affairs"}'
+owner_a:
+- duke
+misc_id_a:
+- 'LCCN: 2009230014'
+- 'GPO Item Number: 1008-C'
+- 'GPO Item Number: 1008-D (microfiche)'
+- 'GPO Item Number: 1008-C (online)'
+- 'GPO Item Number: 1008-D (online)'
+barcodes_a:
+- B930377
+holdings_a:
+- '{"loc_b":"DOCS","loc_n":"PGS","call_no":"Y 1.1/5:"}'
+language_a:
+- English
+local_id: DUKE004093564
+available_a:
+- Available
+frequency_current_a:
+- Biennial
+lang_code_a:
+- eng
+rollup_id: OCLC298561466
+title_suggest:
+- Activities of the Committee on Homeland Security and Governmental Affairs.
+- Report
+- Report.
+title_main: Activities of the Committee on Homeland Security and Governmental Affairs.
+title_sort_ssort_single: activities of the committee on homeland security and governmental
+  affairs
+access_type_a:
+- Online
+- At the Library
+institution_a:
+- duke
+oclc_number: '298561466'
+series_work_a:
+- '{"author":"United States. Congress. Senate.","title":["Report"]}'
+- '{"author":"United States. Congress. Senate.","title":["Report."]}'
+imprint_main_a:
+- '{"type":"imprint","value":"Washington : U.S. G.P.O."}'
+note_general_a:
+- 'Description based on: 109th Congress; title from cover.'
+earlier_work_a:
+- '{"label":"Continues","author":"United States. Congress. Senate. Committee on Governmental
+  Affairs.","title":["Activities of the Committee on Governmental Affairs"]}'
+resource_type_a:
+- Government publication
+- Journal, Magazine, or Periodical
+subject_genre_a:
+- Periodicals
+date_cataloged: '2009-02-15T05:00:00Z'
+genre_headings_a:
+- Periodicals
+subject_suggest:
+- Periodicals
+- United States. Congress. Senate. Committee on Homeland Security and Governmental
+  Affairs -- Periodicals
+- Constitutional law -- United States -- Periodicals
+physical_media_a:
+- Print
+- Online
+subject_topical_a:
+- United States. Congress. Senate. Committee on Homeland Security and Governmental
+  Affairs
+- Constitutional law
+publication_year_sort: '9999'
+subject_headings_a:
+- United States. Congress. Senate. Committee on Homeland Security and Governmental
+  Affairs -- Periodicals
+- Constitutional law -- United States -- Periodicals
+location_hierarchy_a:
+- duke
+- duke:dukeperk
+- duke:dukeperk:dukeperkpdms
+record_data_source_a:
+- ILSMARC
+subject_geographic_a:
+- United States
+physical_description_a:
+- v. ; 24 cm.
+statement_of_responsibility_a:
+- United States. Congress. Senate. Committee on Homeland Security and Governmental
+  Affairs

--- a/spec/fixtures/files/documents/DUKE006162724.yml
+++ b/spec/fixtures/files/documents/DUKE006162724.yml
@@ -1,0 +1,115 @@
+---
+id: DUKE006162724
+url_a:
+- '{"href":"https://proxy.lib.duke.edu/login?url=https://search.ebscohost.com/login.aspx?authtype=ip,uid\u0026custid=s9002128\u0026groupid=main\u0026profile=ehost\u0026defaultdb=s3h","type":"fulltext"}'
+author_suggest:
+- EBSCO Publishing (Firm)
+- Coaching Association of Canada. Sport Information Resource Centre
+names_a:
+- '{"name":"EBSCO Publishing (Firm)"}'
+- '{"name":"Coaching Association of Canada. Sport Information Resource Centre"}'
+owner_a:
+- duke
+misc_id_a:
+- 'LCCN: 2010238303^^'
+holdings_a:
+- '{"loc_b":"DUKIR","loc_n":"MCL"}'
+items_a:
+- '{"loc_b":"DUKIR","loc_n":"MCL","cn_scheme":"","call_no":"Y 1.1/5:","type":"BOOK","item_id":"B930377","status":"Available"}'
+language_a:
+- English
+local_id: DUKE006162724
+available_a:
+- Available
+frequency_current_a:
+- Updated weekly
+lang_code_a:
+- eng
+rollup_id: OCLC69182876
+title_suggest:
+- SPORTDiscus with full text.
+title_main: SPORTDiscus with full text.
+title_sort_ssort_single: sportdiscus with full text
+access_type_a:
+- Online
+institution_a:
+- duke
+oclc_number: '69182876'
+imprint_main_a:
+- '{"type":"imprint","value":"Ipswich, MA : Ebsco Publishing"}'
+note_general_a:
+- Title from database description screen on EBSCO website (viewed March 18, 2010).
+note_summary_a:
+- Bibliographic and full-text database covering both serial and monographic literature
+  on sports, physical fitness, exercise, sports medicine, sports science, physical
+  education, kinesiology, coaching, training, sport administration, officiating, sport
+  law and legislation, disabled athletes, sports facility design and management, intramural
+  and school sports, doping, health, health education, biomechanics, movement science,
+  injury prevention, rehabilitation, physical therapy, nutrition, exercise physiology,
+  recreation, leisure studies, tourism, allied health, occupational health and therapy.
+note_issuance_a:
+- Produced by Sport Information Resource Centre and made available online by EBSCOHost.
+resource_type_a:
+- Database
+subject_genre_a:
+- Indexes
+- Databases
+- Online databases
+- Reference
+date_cataloged: '2014-10-14T04:00:00Z'
+genre_headings_a:
+- Indexes
+- Databases
+- Online databases
+subject_suggest:
+- Indexes
+- Databases
+- Online databases
+- Sports -- Indexes
+- Sports -- Databases
+- Exercise -- Indexes
+- Exercise -- Databases
+- Physical fitness -- Indexes
+- Physical fitness -- Databases
+- Sports medicine -- Indexes
+- Sports medicine -- Databases
+- Coaching (Athletics) -- Indexes
+- Coaching (Athletics) -- Databases
+- Coaching (Athletics)
+- Exercise
+- Physical fitness
+- Sports
+- Sports medicine
+physical_media_a:
+- Online
+subject_topical_a:
+- Sports
+- Exercise
+- Physical fitness
+- Sports medicine
+- Coaching (Athletics)
+publication_year_sort: '9999'
+subject_headings_a:
+- Sports -- Indexes
+- Sports -- Databases
+- Exercise -- Indexes
+- Exercise -- Databases
+- Physical fitness -- Indexes
+- Physical fitness -- Databases
+- Sports medicine -- Indexes
+- Sports medicine -- Databases
+- Coaching (Athletics) -- Indexes
+- Coaching (Athletics) -- Databases
+- Coaching (Athletics)
+- Exercise
+- Physical fitness
+- Sports
+- Sports medicine
+note_serial_dates_a:
+- Began in 2006.
+location_hierarchy_a:
+- duke
+record_data_source_a:
+- ILSMARC
+note_access_restrictions_a:
+- Access restricted to licensed users.

--- a/spec/fixtures/files/documents/UNCb1852218.yml
+++ b/spec/fixtures/files/documents/UNCb1852218.yml
@@ -1,0 +1,61 @@
+---
+id: UNCb1852218
+author_suggest:
+- North Carolina Federation of Music Clubs
+names_a:
+- '{"name":"North Carolina Federation of Music Clubs"}'
+owner_a:
+- unc
+holdings_a:
+- '{"loc_b":"wbda","loc_n":"wbda","call_no":"C780.6 N87f2","summary":"N.C. Collection
+  has bound with other material on the Federation. See entry under North Carolina
+  Federation of Music Clubs with title: Official papers, newsletters, etc."}'
+- '{"loc_b":"wbda","loc_n":"wbda","call_no":"111.222","summary":"Fighting with hornets."}'
+items_a:
+- '{"item_id":"i2698163","loc_b":"trln","loc_n":"trln","status":"Available","cn_scheme":"LC","call_no":"D819.G3
+  T7"}'
+language_a:
+- English
+local_id: b1852218
+lang_code_a:
+- eng
+rollup_id: OCLC8853062
+title_suggest:
+- Musical tempo
+title_main: Musical tempo
+title_sort_ssort_single: Musical tempo
+access_type_a:
+- At the Library
+institution_a:
+- unc
+oclc_number: '8853062'
+imprint_main_a:
+- '{"type":"imprint","value":"Charlotte, N.C. : The Federation,"}'
+note_general_a:
+- 'Description based on: Vol. 15, no. 1 (July 16, 1968).'
+resource_type_a:
+- Journal, Magazine, or Periodical
+date_cataloged: '2004-10-01T04:00:00Z'
+subject_topical_a:
+- North Carolina Federation of Music Clubs
+- Music
+- Music and state
+publication_year_sort: '9999'
+subject_headings_a:
+- North Carolina Federation of Music Clubs
+- Music -- North Carolina
+- Music and state -- North Carolina
+- North Carolina Periodicals
+subject_suggest:
+- North Carolina Federation of Music Clubs
+- Music -- North Carolina
+- Music and state -- North Carolina
+- North Carolina Periodicals
+record_data_source_a:
+- ILSMARC
+subject_geographic_a:
+- North Carolina
+physical_description_a:
+- v. ; 28 cm.
+statement_of_responsibility_a:
+- North Carolina Federation of Music Clubs.

--- a/spec/fixtures/files/documents/UNCb1865787.yml
+++ b/spec/fixtures/files/documents/UNCb1865787.yml
@@ -1,0 +1,83 @@
+---
+id: UNCb1865787
+isbn_number_a:
+- '0042970431'
+isbn_qualifying_info_a:
+- ''
+items_a:
+- '{"item_id":"i2698295","loc_b":"ddda","loc_n":"ddda","status":"Available","cn_scheme":"LC","call_no":"B746
+  .N47 1982"}'
+- '{"item_id":"i2698296","loc_b":"dddb","loc_n":"dddb","status":"Available","copy_no":"c.
+  2","cn_scheme":"LC","call_no":"B746 .N47 1982"}'
+author_suggest:
+- Netton, Ian Richard
+- Ikhwān al-Ṣafāʼ
+names_a:
+- '{"name":"Netton, Ian Richard"}'
+- '{"name":"Ikhwān al-Ṣafāʼ"}'
+owner_a:
+- unc
+misc_id_a:
+- 'LCCN: 83131009'
+barcodes_a:
+- '00002534207'
+- '00002534243'
+language_a:
+- English
+local_id: b1865787
+shelfkey: lc:B..0746.N47.1982
+available_a:
+- Available
+lang_code_a:
+- eng
+rollup_id: OCLC9101267
+title_suggest:
+- 'Muslim neoplatonists : an introduction to the thought of the Brethren of Purity,
+  Ikhwān al-Ṣafāʼ'
+title_main: 'Muslim neoplatonists : an introduction to the thought of the Brethren
+  of Purity, Ikhwān al-Ṣafāʼ'
+title_sort_ssort_single: 'Muslim neoplatonists : an introduction to the thought of
+  the Brethren of Purity, Ikhwān al-Ṣafāʼ'
+access_type_a:
+- At the Library
+institution_a:
+- unc
+oclc_number: '9101267'
+imprint_main_a:
+- '{"type":"imprint","value":"London ; Boston : G. Allen & Unwin, 1982."}'
+note_general_a:
+- Includes index.
+- 'Bibliography: p. [134]-142.'
+resource_type_a:
+- Book
+subject_genre_a:
+- Nonfiction
+date_cataloged: '2004-10-01T04:00:00Z'
+physical_media_a:
+- Print
+subject_topical_a:
+- Ikhwān al-Ṣafāʼ
+publication_year_sort: '1982'
+reverse_shelfkey: lc:O}}ZSVT}CVS}YQRX
+subject_headings_a:
+- Ikhwān al-Ṣafāʼ
+subject_suggest:
+- Ikhwān al-Ṣafāʼ
+location_hierarchy_a:
+- unc
+- unc:uncdavy
+record_data_source_a:
+- ILSMARC
+call_number_schemes_a:
+- LC
+physical_description_a:
+- x, 146 p. ; 23 cm.
+lcc_callnum_classification_a:
+- B - Philosophy. Psychology. Religion
+- B - Philosophy. Psychology. Religion|B1 - B5802 Philosophy (General)
+- B - Philosophy. Psychology. Religion|B1 - B5802 Philosophy (General)|B108 - B5802
+  By period
+- B - Philosophy. Psychology. Religion|B1 - B5802 Philosophy (General)|B108 - B5802
+  By period|B720 - B765 Medieval
+statement_of_responsibility_a:
+- Ian Richard Netton.

--- a/spec/fixtures/files/holdings/UNCb1852218_expectation.yml
+++ b/spec/fixtures/files/holdings/UNCb1852218_expectation.yml
@@ -1,0 +1,21 @@
+---
+trln:
+  trln:
+    items:
+    - item_id: i2698163
+      status: Available
+      cn_scheme: LC
+      call_no: D819.G3 T7
+    holdings:
+    - summary: ''
+      call_no: D819.G3 T7
+wbda:
+  wbda:
+    items: []
+    holdings:
+    - call_no: C780.6 N87f2
+      summary: 'N.C. Collection has bound with other material on the Federation. See
+        entry under North Carolina Federation of Music Clubs with title: Official
+        papers, newsletters, etc.'
+    - call_no: '111.222'
+      summary: Fighting with hornets.

--- a/spec/fixtures/files/holdings/UNCb1865787_expectation.yml
+++ b/spec/fixtures/files/holdings/UNCb1865787_expectation.yml
@@ -1,0 +1,22 @@
+---
+ddda:
+  ddda:
+    items:
+    - item_id: i2698295
+      status: Available
+      cn_scheme: LC
+      call_no: B746 .N47 1982
+    holdings:
+    - summary: ''
+      call_no: B746 .N47
+dddb:
+  dddb:
+    items:
+    - item_id: i2698296
+      status: Available
+      copy_no: c. 2
+      cn_scheme: LC
+      call_no: B746 .N47 1982
+    holdings:
+    - summary: ''
+      call_no: B746 .N47

--- a/spec/fixtures/files/holdings/items_with_holdings_no_summary.yml
+++ b/spec/fixtures/files/holdings/items_with_holdings_no_summary.yml
@@ -1,0 +1,15 @@
+---
+PERKN:
+  PKW:
+    items:
+    - cn_scheme: LC
+      call_no: PS3551.C44 G743 2018
+      type: BOOK
+      item_id: D05261611M
+      status: Available
+    holdings:
+    - call_no: PS3551.C44 G743 2018
+  PK:
+    items: []
+    holdings:
+    - call_no: PS3551.C44 G743 2018

--- a/spec/fixtures/files/holdings/items_with_holdings_with_summary.yml
+++ b/spec/fixtures/files/holdings/items_with_holdings_with_summary.yml
@@ -1,0 +1,32 @@
+---
+LSC:
+  PSKP:
+    items:
+    - cn_scheme: '5'
+      call_no: T289A
+      copy_no: v.1+3=issue2+11(1993-1994) c.1
+      notes:
+      - missing v.2 (Sep./Oct. 1994)=issue 10
+      type: BPER
+      item_id: D03445982Z
+      status: Available
+    - cn_scheme: '5'
+      call_no: T289A
+      copy_no: v.3=issue 12+15(Jan./Feb.-July/Aug. 1995) c.1
+      type: BPER
+      item_id: D03445983-
+      status: Available
+    holdings:
+    - call_no: T289A
+      summary: 'LIBRARY HAS: v.1(1993)-v.2(1994)=issue1-9&11; v.3(1995)=issue12-15'
+  PSK:
+    items:
+    - cn_scheme: '5'
+      call_no: T289A
+      copy_no: v.1=issue1(1992) c.1
+      type: BPER
+      item_id: D01297891.
+      status: Available
+    holdings:
+    - call_no: T289A
+      summary: 'LIBRARY HAS: v.1(1993)-v.2(1994)=issue1-9&11; v.3(1995)=issue12-15'

--- a/spec/fixtures/files/holdings/no_items_no_holdings.yml
+++ b/spec/fixtures/files/holdings/no_items_no_holdings.yml
@@ -1,0 +1,6 @@
+---
+PERKN:
+  PEI:
+    items: []
+    holdings:
+      - {}

--- a/spec/fixtures/files/holdings/no_items_with_holdings_has_summary.yml
+++ b/spec/fixtures/files/holdings/no_items_with_holdings_has_summary.yml
@@ -1,0 +1,13 @@
+---
+PERKN:
+  PEI:
+    items: []
+    holdings:
+    - summary: 'Available at address: http://wwwrvares.er.usgs.gov/nawqa/WRI94-4001.html'
+DOCS:
+  PGS:
+    items: []
+    holdings:
+    - notes:
+      - Not distributed in print; see online version
+      call_no: I 19.42/4:94-4001

--- a/spec/fixtures/files/holdings/no_items_with_holdings_no_summary.yml
+++ b/spec/fixtures/files/holdings/no_items_with_holdings_no_summary.yml
@@ -1,0 +1,7 @@
+---
+DOCS:
+  PGS:
+    items: []
+    holdings:
+      - summary: ''
+        call_no: I 19.42/4:94-4001

--- a/spec/fixtures/files/holdings/online_only_holdings.yml
+++ b/spec/fixtures/files/holdings/online_only_holdings.yml
@@ -1,0 +1,13 @@
+---
+ONLINE:
+  PEI:
+    items: []
+    holdings:
+    - summary: 'Available at address: http://wwwrvares.er.usgs.gov/nawqa/WRI94-4001.html'
+DUKIR:
+  PGS:
+    items: []
+    holdings:
+    - notes:
+      - Not distributed in print; see online version
+      call_no: I 19.42/4:94-4001

--- a/spec/lib/trln_argon/argon_search_builder_spec.rb
+++ b/spec/lib/trln_argon/argon_search_builder_spec.rb
@@ -63,6 +63,21 @@ describe TrlnArgon::ArgonSearchBuilder do
     end
   end
 
+  describe 'wildcard_char_strip' do
+    before do
+      builder_with_params.add_query_to_solr(solr_parameters)
+      builder_with_params.wildcard_char_strip(solr_parameters)
+    end
+
+    context 'query contains question marks' do
+      let(:builder_with_params) { search_builder.with(q: 'What? Will? Humans? Do?') }
+
+      it 'removes question marks from the query' do
+        expect(solr_parameters[:q]).to eq('What Will Humans Do')
+      end
+    end
+  end
+
   describe 'min_match_for_boolean' do
     before { builder_with_params.min_match_for_boolean(solr_parameters) }
 

--- a/spec/lib/trln_argon/item_deserializer_spec.rb
+++ b/spec/lib/trln_argon/item_deserializer_spec.rb
@@ -1,0 +1,32 @@
+describe TrlnArgon::ItemDeserializer do
+  class SolrDocumentTestClass
+    include Blacklight::Solr::Document
+    include TrlnArgon::ItemDeserializer
+  end
+
+  context 'document has items but no holdings' do
+    let(:document) do
+      SolrDocumentTestClass.new(YAML.safe_load(file_fixture('documents/UNCb1865787.yml').read))
+    end
+    let(:expectation) do
+      YAML.safe_load(file_fixture('holdings/UNCb1865787_expectation.yml').read)
+    end
+
+    it 'generates holdings info' do
+      expect(document.holdings).to eq(expectation)
+    end
+  end
+
+  context 'document has items and holdings with different locations' do
+    let(:document) do
+      SolrDocumentTestClass.new(YAML.safe_load(file_fixture('documents/UNCb1852218.yml').read))
+    end
+    let(:expectation) do
+      YAML.safe_load(file_fixture('holdings/UNCb1852218_expectation.yml').read)
+    end
+
+    it 'generates holdings info' do
+      expect(document.holdings).to eq(expectation)
+    end
+  end
+end

--- a/spec/lib/trln_argon/search_builder/default_local_search_builder_spec.rb
+++ b/spec/lib/trln_argon/search_builder/default_local_search_builder_spec.rb
@@ -2,6 +2,10 @@ describe DefaultLocalSearchBuilder do
   let(:obj) { described_class.new(CatalogController.new) }
 
   describe 'processor chain' do
+    it 'adds the wildcard_char_strip method to the processor chain' do
+      expect(obj.processor_chain).to include(:wildcard_char_strip)
+    end
+
     it 'adds the min_match_for_cjk method to the processor chain' do
       expect(obj.processor_chain).to include(:min_match_for_cjk)
     end

--- a/spec/lib/trln_argon/search_builder/default_trln_search_builder_spec.rb
+++ b/spec/lib/trln_argon/search_builder/default_trln_search_builder_spec.rb
@@ -2,6 +2,10 @@ describe DefaultTrlnSearchBuilder do
   let(:obj) { described_class.new(CatalogController.new) }
 
   describe 'processor chain' do
+    it 'adds the wildcard_char_strip method to the processor chain' do
+      expect(obj.processor_chain).to include(:wildcard_char_strip)
+    end
+
     it 'adds the min_match_for_cjk method to the processor chain' do
       expect(obj.processor_chain).to include(:min_match_for_cjk)
     end

--- a/spec/lib/trln_argon/solr_document_spec.rb
+++ b/spec/lib/trln_argon/solr_document_spec.rb
@@ -421,8 +421,7 @@ describe TrlnArgon::SolrDocument do
       SolrDocument.new(YAML.safe_load(file_fixture('documents/DUKE002952265.yml').read).first)
     end
 
-    # Skip until pub date is indexed correctly
-    xit 'exports the document as RIS' do
+    it 'exports the document as RIS' do
       expect(test_document.export_as_ris).to eq(
         "TY  - BOOK\r\n"\
         "A1  - Maureen E. Downey.\r\n"\
@@ -471,8 +470,7 @@ describe TrlnArgon::SolrDocument do
                                'of\+a\+new\+genus\+and\+family\+%2F')
     end
 
-    # Skip until pub date is indexed correctly
-    xit 'contains an rft.date' do
+    it 'contains an rft.date' do
       expect(ctx_kev).to match('rft.date=1986')
     end
 
@@ -499,8 +497,7 @@ describe TrlnArgon::SolrDocument do
     end
 
     # rubocop:disable ExampleLength
-    # Skip until pub date is indexed correctly
-    xit 'exports the document to email text' do
+    it 'exports the document to email text' do
       expect(test_document.to_email_text).to eq(
         "\n"\
         "Title:\n"\
@@ -537,8 +534,7 @@ describe TrlnArgon::SolrDocument do
       SolrDocument.new(YAML.safe_load(file_fixture('documents/DUKE002952265.yml').read).first)
     end
 
-    # Skip until pub date is indexed correctly
-    xit 'exports the document to email text' do
+    it 'exports the document to email text' do
       expect(test_document.to_email_text).to eq(
         "\n"\
         "Title:\n"\

--- a/spec/lib/trln_argon/view_helpers/items_section_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/items_section_helper_spec.rb
@@ -5,7 +5,7 @@ describe TrlnArgon::ViewHelpers::ItemsSectionHelper, type: :helper do
   end
 
   let(:unc_item_data) do
-    unc_serial_with_holdings_id.holdings['trln']['trln']
+    unc_serial_with_holdings_id.holdings['trln']['trln']['holdings'].first
   end
 
   let(:ncsu_serial_with_lr_text) do
@@ -14,7 +14,7 @@ describe TrlnArgon::ViewHelpers::ItemsSectionHelper, type: :helper do
   end
 
   let(:ncsu_item_data) do
-    ncsu_serial_with_lr_text.holdings['DHHILL']['STACKS']
+    ncsu_serial_with_lr_text.holdings['DHHILL']['STACKS']['holdings'].first
   end
 
   context '#latest_received' do

--- a/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
@@ -430,6 +430,114 @@ describe TrlnArgonHelper, type: :helper do
     end
   end
 
+  describe '#online_only_items?' do
+    context 'location codes are online' do
+      let(:holdings) do
+        YAML.safe_load(file_fixture('holdings/online_only_holdings.yml').read)
+      end
+      let(:loc_b) { holdings.keys.first }
+      let(:loc_n) { holdings[loc_b].keys.first }
+      let(:item_data) do
+        holdings[loc_b][loc_n]
+      end
+
+      it 'returns true' do
+        expect(online_only_items?(loc_b: loc_b, loc_n: loc_n, item_data: item_data)).to(
+          be true
+        )
+      end
+    end
+
+    context 'location codes are physical' do
+      let(:holdings) do
+        YAML.safe_load(file_fixture('holdings/items_with_holdings_no_summary.yml').read)
+      end
+      let(:loc_b) { holdings.keys.first }
+      let(:loc_n) { holdings[loc_b].keys.first }
+      let(:item_data) do
+        holdings[loc_b][loc_n]
+      end
+
+      it 'returns false' do
+        expect(online_only_items?(loc_b: loc_b, loc_n: loc_n, item_data: item_data)).to(
+          be false
+        )
+      end
+    end
+  end
+
+  describe '#no_items_no_holdings?' do
+    context 'location has no items and no holdings' do
+      let(:holdings) do
+        YAML.safe_load(file_fixture('holdings/no_items_no_holdings.yml').read)
+      end
+      let(:loc_b) { holdings.keys.first }
+      let(:loc_n) { holdings[loc_b].keys.first }
+      let(:item_data) do
+        holdings[loc_b][loc_n]
+      end
+
+      it 'returns true' do
+        expect(no_items_no_holdings?(loc_b: loc_b, loc_n: loc_n, item_data: item_data)).to(
+          be true
+        )
+      end
+    end
+
+    context 'location has items' do
+      let(:holdings) do
+        YAML.safe_load(file_fixture('holdings/items_with_holdings_no_summary.yml').read)
+      end
+      let(:loc_b) { holdings.keys.first }
+      let(:loc_n) { holdings[loc_b].keys.first }
+      let(:item_data) do
+        holdings[loc_b][loc_n]
+      end
+
+      it 'returns false' do
+        expect(no_items_no_holdings?(loc_b: loc_b, loc_n: loc_n, item_data: item_data)).to(
+          be false
+        )
+      end
+    end
+  end
+
+  describe 'no_items_holdings_no_summary?' do
+    context 'location has no items and holdings without summaries' do
+      let(:holdings) do
+        YAML.safe_load(file_fixture('holdings/no_items_with_holdings_no_summary.yml').read)
+      end
+      let(:loc_b) { holdings.keys.first }
+      let(:loc_n) { holdings[loc_b].keys.first }
+      let(:item_data) do
+        holdings[loc_b][loc_n]
+      end
+
+      it 'returns true' do
+        expect(no_items_holdings_no_summary?(loc_b: loc_b, loc_n: loc_n, item_data: item_data)).to(
+          be true
+        )
+      end
+    end
+
+    context 'location has no items but has holdings with summaries' do
+      let(:holdings) do
+        YAML.safe_load(file_fixture('holdings/no_items_with_holdings_has_summary.yml').read)
+      end
+      let(:loc_b) { holdings.keys.first }
+      let(:loc_n) { holdings[loc_b].keys.first }
+      let(:item_data) do
+        holdings[loc_b][loc_n]
+      end
+
+      it 'returns false' do
+        expect(no_items_holdings_no_summary?(loc_b: loc_b, loc_n: loc_n, item_data: item_data)).to(
+          be false
+        )
+      end
+    end
+  end
+
   describe '#display_items?' do
     context 'only online holdings keys' do
       let(:document) do
@@ -487,6 +595,102 @@ describe TrlnArgonHelper, type: :helper do
 
       it 'returns true' do
         expect(helper.suppress_item?(item_data: item_data, loc_b: loc_b)).to be false
+      end
+    end
+  end
+
+  describe '#display_holdings_summaries?' do
+    context 'holdings have summaries' do
+      let(:options) do
+        { 'holdings' => [{ 'summary' => '1659 to 1805' }] }
+      end
+
+      it 'returns true' do
+        expect(helper.display_holdings_summaries?(options)).to be true
+      end
+    end
+
+    context 'holdings have notes' do
+      let(:options) do
+        { 'holdings' => [{ 'notes' => ['Shelved with other things.'] }] }
+      end
+
+      it 'returns true' do
+        expect(helper.display_holdings_summaries?(options)).to be true
+      end
+    end
+
+    context 'holdings do not have summaries or notes' do
+      let(:options) do
+        { 'holdings' => [{ 'call_no' => 'AAA111 .B3 1999' }] }
+      end
+
+      it 'returns false' do
+        expect(helper.display_holdings_summaries?(options)).to be false
+      end
+    end
+  end
+
+  describe '#display_holdings_summary?' do
+    context 'holding has a summary' do
+      let(:options) do
+        { 'summary' => '1659 to 1805' }
+      end
+
+      it 'returns true' do
+        expect(helper.display_holdings_summary?(options)).to be true
+      end
+    end
+
+    context 'holding has notes' do
+      let(:options) do
+        { 'notes' => ['Shelved with bees.'] }
+      end
+
+      it 'returns true' do
+        expect(helper.display_holdings_summary?(options)).to be true
+      end
+    end
+
+    context 'holding does not have summary or notes' do
+      let(:options) do
+        { 'call_no' => 'AAA111 .B3 1999' }
+      end
+
+      it 'returns true' do
+        expect(helper.display_holdings_summary?(options)).to be false
+      end
+    end
+  end
+
+  describe 'add_spacer_above_items_section?' do
+    context 'record has items and links' do
+      let(:document) do
+        SolrDocument.new(YAML.safe_load(file_fixture('documents/DUKE004093564.yml').read))
+      end
+
+      it 'returns true' do
+        expect(add_spacer_above_items_section?(document: document)).to be true
+      end
+    end
+
+    context 'record has items but no links' do
+      let(:document) do
+        SolrDocument.new(YAML.safe_load(file_fixture('documents/UNCb1852218.yml').read))
+      end
+
+      it 'returns false' do
+        expect(add_spacer_above_items_section?(document: document)).to be false
+      end
+    end
+
+    context 'record has links but no items' do
+      let(:document) do
+        SolrDocument.new(YAML.safe_load(file_fixture('documents/DUKE006162724.yml').read))
+      end
+
+      it 'returns false' do
+        expect(add_spacer_above_items_section?(document: document)).to be false
       end
     end
   end


### PR DESCRIPTION
**NOTE: PR is against develop branch.**

* Primary change is to allow more than one holdings entry per location. This has wide impact at Duke where we have Dewey and LC material with separate summaries.
* Remove question marks from queries to prevent edismax from parsing as wildcard character.
* Allow for display of holdings summaries/notes even when there are no items associated with the location.
* Tests....

**Some examples**
Display holdings without items: UNCb1852218
Location with multiple holdings summaries: DUKE002480820