### PR TITLE
Display holdings if a holdings_id is present.

### DIFF
--- a/app/views/catalog/_items_section_summary.html.erb
+++ b/app/views/catalog/_items_section_summary.html.erb
@@ -40,10 +40,12 @@
             </dl>
           </div>
 
-          <% # --- LATEST RECEIVED --- %>
+        <% end %>
 
+        <% # --- LATEST RECEIVED --- %>
+
+        <% if h.fetch('holdings_id', '').present? %>
           <%= render partial: 'catalog/index_items_latest_received', locals: { document: @document, item_data: h } %>
-
         <% end %>
 
         <% # --- HOLDING NOTES --- %>

--- a/lib/trln_argon/view_helpers/items_section_helper.rb
+++ b/lib/trln_argon/view_helpers/items_section_helper.rb
@@ -83,11 +83,16 @@ module TrlnArgon
 
       def display_holdings_summaries?(options = {})
         holdings = options.fetch('holdings', [])
-        holdings.find { |h| h.fetch('summary', '').present? || h.fetch('notes', []).any? }.present?
+        displayable_holdings = holdings.find do |h|
+          display_holdings_summary?(h)
+        end
+        displayable_holdings.present?
       end
 
       def display_holdings_summary?(options = {})
-        options.fetch('summary', '').present? || options.fetch('notes', []).any?
+        options.fetch('summary', '').present? ||
+          options.fetch('notes', []).any? ||
+          options.fetch('holdings_id', '').present?
       end
 
       def display_holdings_well?(options = {})
@@ -137,7 +142,7 @@ module TrlnArgon
         item_data = options.fetch(:item_data, {})
         holdings = item_data.fetch('holdings', []).reject(&:empty?)
         holdings.any? &&
-          holdings.select { |j| j.fetch('summary', '').present? || j.fetch('notes', []).any? }.none? &&
+          holdings.select { |h| display_holdings_summary?(h) }.none? &&
           item_data.fetch('items').reject(&:empty?).none?
       end
 

--- a/spec/fixtures/files/documents/UNCb3922162.yml
+++ b/spec/fixtures/files/documents/UNCb3922162.yml
@@ -1,0 +1,69 @@
+---
+id: UNCb3922162
+author_suggest:
+- Harvard Forest (Research facility)
+- Harvard Black Rock Forest (Research facility)
+names_a:
+- '{"name":"Harvard Forest (Research facility)"}'
+- '{"name":"Harvard Black Rock Forest (Research facility)"}'
+owner_a:
+- unc
+holdings_a:
+- '{"holdings_id":"c2799223","loc_b":"bb","loc_n":"bb"}'
+language_a:
+- English
+local_id: b3922162
+frequency_current_a:
+- Annual
+lang_code_a:
+- eng
+rollup_id: OCLC18340267
+title_suggest:
+- The Harvard Forest and Harvard Black Rock Forest annual report
+title_main: The Harvard Forest and Harvard Black Rock Forest annual report
+title_sort_ssort_single: harvard forest and harvard black rock forest annual report
+access_type_a:
+- At the Library
+institution_a:
+- unc
+oclc_number: '18340267'
+imprint_main_a:
+- '{"type":"imprint","value":"Petersham, Mass. : The University,"}'
+note_general_a:
+- 'Description based on: 1966-67.'
+later_work_a:
+- '{"label":"Continued by","author":"Harvard Forest (Research facility).","title":["Harvard
+  forest"]}'
+resource_type_a:
+- Journal, Magazine, or Periodical
+subject_genre_a:
+- Periodicals
+date_cataloged: '2004-10-01T04:00:00Z'
+genre_headings_a:
+- Periodicals
+subject_suggest:
+- Periodicals
+- Harvard Forest (Research facility)
+- Forests and forestry -- Research -- Periodicals
+- Black Rock Forest (N.Y.)
+note_numbering_a:
+- Report year ends June 30.
+subject_topical_a:
+- Harvard Forest (Research facility)
+- Forests and forestry
+- Research
+publication_year_sort: '1967'
+subject_headings_a:
+- Harvard Forest (Research facility)
+- Forests and forestry -- Research -- Periodicals
+- Black Rock Forest (N.Y.)
+note_serial_dates_a:
+- "-1966-67."
+record_data_source_a:
+- ILSMARC
+subject_geographic_a:
+- Black Rock Forest (N.Y.)
+physical_description_a:
+- v. ; 22 cm.
+statement_of_responsibility_a:
+- Harvard University.

--- a/spec/fixtures/files/holdings/no_items_with_holdings_has_holdings_id.yml
+++ b/spec/fixtures/files/holdings/no_items_with_holdings_has_holdings_id.yml
@@ -1,0 +1,6 @@
+---
+bb:
+  bb:
+    items: []
+    holdings:
+    - holdings_id: c2799223

--- a/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
@@ -428,6 +428,18 @@ describe TrlnArgonHelper, type: :helper do
         expect(helper.display_holdings_well?(document: document)).to be true
       end
     end
+
+    context 'no items but has a holdings id' do
+      let(:document) do
+        SolrDocument.new(
+          YAML.safe_load(file_fixture('documents/UNCb3922162.yml').read)
+        )
+      end
+
+      it 'returns true' do
+        expect(helper.display_holdings_well?(document: document)).to be true
+      end
+    end
   end
 
   describe '#online_only_items?' do
@@ -536,6 +548,23 @@ describe TrlnArgonHelper, type: :helper do
         )
       end
     end
+
+    context 'location has no items but has holdings with holdings_id' do
+      let(:holdings) do
+        YAML.safe_load(file_fixture('holdings/no_items_with_holdings_has_holdings_id.yml').read)
+      end
+      let(:loc_b) { holdings.keys.first }
+      let(:loc_n) { holdings[loc_b].keys.first }
+      let(:item_data) do
+        holdings[loc_b][loc_n]
+      end
+
+      it 'returns false' do
+        expect(no_items_holdings_no_summary?(loc_b: loc_b, loc_n: loc_n, item_data: item_data)).to(
+          be false
+        )
+      end
+    end
   end
 
   describe '#display_items?' do
@@ -568,6 +597,18 @@ describe TrlnArgonHelper, type: :helper do
         expect(helper.display_items?(document: document)).to be true
       end
     end
+
+    context 'document has no items but has holdings with holdings_id' do
+      let(:document) do
+        SolrDocument.new(
+          YAML.safe_load(file_fixture('documents/UNCb3922162.yml').read)
+        )
+      end
+
+      it 'returns true' do
+        expect(helper.display_items?(document: document)).to be true
+      end
+    end
   end
 
   describe '#suppress_item?' do
@@ -589,11 +630,20 @@ describe TrlnArgonHelper, type: :helper do
       end
     end
 
+    context 'no items but has holdings_id' do
+      let(:item_data) { { 'items' => [], 'holdings' => [{ 'holdings_id' => '123456789' }] } }
+      let(:loc_b) { 'dddr' }
+
+      it 'returns false' do
+        expect(helper.suppress_item?(item_data: item_data, loc_b: loc_b)).to be false
+      end
+    end
+
     context 'displayable item' do
       let(:item_data) { { 'items' => ['an item'] } }
       let(:loc_b) { 'PERK' }
 
-      it 'returns true' do
+      it 'returns false' do
         expect(helper.suppress_item?(item_data: item_data, loc_b: loc_b)).to be false
       end
     end
@@ -613,6 +663,16 @@ describe TrlnArgonHelper, type: :helper do
     context 'holdings have notes' do
       let(:options) do
         { 'holdings' => [{ 'notes' => ['Shelved with other things.'] }] }
+      end
+
+      it 'returns true' do
+        expect(helper.display_holdings_summaries?(options)).to be true
+      end
+    end
+
+    context 'holdings have holdings_id' do
+      let(:options) do
+        { 'holdings' => [{ 'holdings_id' => '123456789' }] }
       end
 
       it 'returns true' do
@@ -645,6 +705,16 @@ describe TrlnArgonHelper, type: :helper do
     context 'holding has notes' do
       let(:options) do
         { 'notes' => ['Shelved with bees.'] }
+      end
+
+      it 'returns true' do
+        expect(helper.display_holdings_summary?(options)).to be true
+      end
+    end
+
+    context 'holding has holdings_id' do
+      let(:options) do
+        { 'holdings_id' => '123456' }
       end
 
       it 'returns true' do


### PR DESCRIPTION
Some UNC records don't have items and don't have summaries or notes but have an ID for latest received and these should display.