### PR TITLE
adds labels to radio inputs on advanced search form

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -1580,8 +1580,13 @@ h2.local-filter-heading  {
 
 /* Advanced Search */
 
-.blacklight-advanced .search-query-form, .blacklight-advanced_trln .search-query-form {
-  display: none;
+.blacklight-advanced {
+  .search-query-form, .blacklight-advanced_trln .search-query-form {
+    display: none;
+  }
+  form.advanced span.option-wrapper {
+    display: inline-block;
+  }
 }
 
 /* AxS Tweaks */

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -11,8 +11,12 @@
 
       <div class="query-criteria"> 
         <h3 class="query-criteria-heading"><%= "#{t("blacklight_advanced_search.form.show_results_from")}" %></h3>
-        <%= radio_button_tag :option, "catalog" %> <%= "#{t("trln_argon.local_filter.searching_local", local_institution_name: institution_long_name)}" %> &emsp;
-        <%= radio_button_tag  :option, "trln" %> <%= "#{t("trln_argon.local_filter.searching_trln")}" %>
+        <span class="option-wrapper">
+          <%= radio_button_tag :option, "catalog" %> <%= label_tag 'option_catalog', "#{t("trln_argon.local_filter.searching_local", local_institution_name: institution_long_name)}" %> &emsp;
+        </span>
+        <span class="option-wrapper">
+          <%= radio_button_tag  :option, "trln" %> <%= label_tag 'option_trln', "#{t("trln_argon.local_filter.searching_trln")}" %>
+        </span>
       </div>
 
       <div class="query-criteria">

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.1.2'.freeze
 end


### PR DESCRIPTION
Bigger text gives the new radio inputs on the advanced search page an undesirable wrap on small screens. 

![Screen Shot 2019-04-11 at 12 00 21 PM](https://user-images.githubusercontent.com/3514165/55980403-673b4a00-5c62-11e9-8534-af18379400a0.png)

This PR fixes that by wrapping them in a span that's given an inline-block display.  While we're at it, we added label tags to the labels so they are clickable to help with accessibility.

![Screen Shot 2019-04-11 at 12 00 43 PM](https://user-images.githubusercontent.com/3514165/55980542-ae293f80-5c62-11e9-9972-cda38defb587.png)