### PR TITLE
update NCSU long name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
 rvm:
-  - 2.4.4
-before_install: gem install bundler -v 1.12.5
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
+before_install: gem install bundler -v 2.0.1

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -60,7 +60,7 @@ en:
                 long_name: "NCCU Libraries"
             ncsu:
                 short_name: "NC State"
-                long_name: "NC State Libraries"
+                long_name: "NC State University Libraries"
             unc:
                 short_name: "UNC"
                 long_name: "UNC Libraries"

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '1.1.4'.freeze
+  VERSION = '1.1.5'.freeze
 end

--- a/spec/features/full_records_spec.rb
+++ b/spec/features/full_records_spec.rb
@@ -22,7 +22,7 @@ describe 'full records' do
     end
 
     it 'shows location information for NCSU' do
-      expect(page).to have_css('#doc_duke002952265 h3', text: 'NC State Libraries')
+      expect(page).to have_css('#doc_duke002952265 h3', text: 'NC State University Libraries')
     end
   end
 

--- a/trln_argon.gemspec
+++ b/trln_argon.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'openurl', '~>1.0'
   s.add_dependency 'font-awesome-rails', '~> 4.7'
   s.add_dependency 'bootstrap-select-rails', '~> 1.12'
-  s.add_dependency 'chosen-rails', '~> 1.8'
+  s.add_dependency 'chosen-rails', '~> 1.8.7'
+  s.add_dependency 'coffee-rails', '~> 4.2'
   s.add_dependency 'rsolr', '>= 1.0', '< 3'
   s.add_dependency 'addressable', '~> 2.5'
 


### PR DESCRIPTION
`ncsu` long name should be "NC State University Libraries" (distinguishes TRLN partner from the State Library of NC)