### PR TITLE
Td 851 reload mappings

### DIFF
--- a/lib/generators/trln_argon/templates/solr_document.rb
+++ b/lib/generators/trln_argon/templates/solr_document.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SolrDocument
+  include SolrDocumentBehavior
+end

--- a/lib/generators/trln_argon/templates/solr_document_behavior.rb
+++ b/lib/generators/trln_argon/templates/solr_document_behavior.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SolrDocumentBehavior
+  extend ActiveSupport::Concern
+
+  included do
+    send(:include, Blacklight::Solr::Document)
+    # This is needed so that find will work correctly
+    # from the Rails console with our Solr configuration.
+    # Otherwise, it tries to use the non-existent document request handler.
+    repository.blacklight_config.document_solr_path = :document
+    repository.blacklight_config.document_solr_request_handler = nil
+    use_extension(TrlnArgon::DocumentExtensions::Ris)
+    use_extension(TrlnArgon::DocumentExtensions::OpenurlCtxKev)
+    use_extension(TrlnArgon::DocumentExtensions::Email)
+    use_extension(TrlnArgon::DocumentExtensions::Sms)
+    use_extension(Blacklight::Document::DublinCore)
+
+    send(:include, TrlnArgon::SolrDocument)
+    send(:include, TrlnArgon::ItemDeserializer)
+  end
+end

--- a/lib/generators/trln_argon/templates/trln_controller.rb
+++ b/lib/generators/trln_argon/templates/trln_controller.rb
@@ -1,0 +1,7 @@
+class TrlnController < CatalogController
+  include TrlnArgon::TrlnControllerBehavior
+
+  configure_blacklight do |config|
+    config.document_model = TrlnSolrDocument
+  end
+end

--- a/lib/generators/trln_argon/templates/trln_solr_document.rb
+++ b/lib/generators/trln_argon/templates/trln_solr_document.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class TrlnSolrDocument
+  include SolrDocumentBehavior
+  include TrlnArgon::TrlnSolrDocument
+end

--- a/lib/trln_argon.rb
+++ b/lib/trln_argon.rb
@@ -17,5 +17,6 @@ module TrlnArgon
   autoload :SolrEscape, 'trln_argon/solr_escape'
   autoload :SyndeticsData, 'trln_argon/syndetics_data'
   autoload :TrlnControllerBehavior, 'trln_argon/trln_controller_behavior'
+  autoload :TrlnSolrDocument, 'trln_argon/trln_solr_document'
   autoload :ViewHelpers, 'trln_argon/view_helpers'
 end

--- a/lib/trln_argon/mappings.rb
+++ b/lib/trln_argon/mappings.rb
@@ -45,11 +45,11 @@ module TrlnArgon
 
         head_fetch_file = File.join(@repo_dir, '.git', 'FETCH_HEAD')
 
-        if File.exist?(head_fetch_file)
-          # this method might get called in a loop when, e.g. creating
-          # an engine_cart instance, so we need a very short term cache.
-          do_pull = File.stat(head_fetch_file).mtime < (Time.now - 2.minutes)
-        end
+        do_pull = if File.exist?(head_fetch_file)
+                    File.stat(head_fetch_file).mtime < (Time.now - 2.minutes)
+                  else
+                    true
+                  end
 
         if do_pull
           logger.info("Pulling changes from #{@url}")

--- a/lib/trln_argon/mappings.rb
+++ b/lib/trln_argon/mappings.rb
@@ -40,7 +40,7 @@ module TrlnArgon
     def refresh
       if File.directory?(File.join(@repo_dir, '.git'))
         @git ||= Git.init(@repo_dir)
-        do_pull = false
+
         logger.info("Repository #{@url} has already been cloned")
 
         head_fetch_file = File.join(@repo_dir, '.git', 'FETCH_HEAD')

--- a/lib/trln_argon/solr_document.rb
+++ b/lib/trln_argon/solr_document.rb
@@ -52,6 +52,13 @@ module TrlnArgon
         ).map { |isbn_info_pairs| isbn_info_pairs.join(' ') }
     end
 
+    # Needed so that document export functions can generate a link
+    # back to the record without the controller context.
+    def link_to_record
+      TrlnArgon::Engine.configuration.root_url.chomp('/') +
+        Rails.application.routes.url_helpers.solr_document_path(self)
+    end
+
     def marc_summary
       format_for_display(self[TrlnArgon::Fields::NOTE_SUMMARY])
     end

--- a/lib/trln_argon/solr_document/email_field_mapping.rb
+++ b/lib/trln_argon/solr_document/email_field_mapping.rb
@@ -8,15 +8,11 @@ module TrlnArgon
       # For more complex data mappings see proc examples.
 
       # rubocop:disable MethodLength
-      # rubocop:disable AbcSize
       def email_field_mapping
         @email_field_mapping ||= {
           title: TrlnArgon::Fields::TITLE_MAIN,
           author: proc { names_to_text },
-          link_to_record: proc do
-                            TrlnArgon::Engine.configuration.root_url.chomp('/') +
-                              Rails.application.routes.url_helpers.solr_document_path(self)
-                          end,
+          link_to_record: proc { link_to_record },
           location: proc { holdings_to_text },
           publisher: proc { imprint_main_to_text },
           edition: TrlnArgon::Fields::EDITION,

--- a/lib/trln_argon/solr_document/openurl_ctx_kev_field_mapping.rb
+++ b/lib/trln_argon/solr_document/openurl_ctx_kev_field_mapping.rb
@@ -13,10 +13,7 @@ module TrlnArgon
           # TODO: Do something sensible when format is more settled
           format: proc { 'book' },
           identifiers: [
-            proc do
-              TrlnArgon::Engine.configuration.root_url.chomp('/') +
-                Rails.application.routes.url_helpers.solr_document_path(self)
-            end
+            proc { link_to_record }
           ],
           metadata: {
             au: TrlnArgon::Fields::STATEMENT_OF_RESPONSIBILITY,

--- a/lib/trln_argon/solr_document/ris_field_mapping.rb
+++ b/lib/trln_argon/solr_document/ris_field_mapping.rb
@@ -48,10 +48,7 @@ module TrlnArgon
           # Secondary Title (journal title, if applicable)
           # T2: ,
           # URL
-          UR: proc do
-                TrlnArgon::Engine.configuration.root_url.chomp('/') +
-                  Rails.application.routes.url_helpers.solr_document_path(self)
-              end
+          UR: proc { link_to_record }
         }
       end
 

--- a/lib/trln_argon/trln_solr_document.rb
+++ b/lib/trln_argon/trln_solr_document.rb
@@ -1,0 +1,11 @@
+module TrlnArgon
+  # SolrDocument behaviors needed in the TRLN Controller Context
+  module TrlnSolrDocument
+    # Needed so that document export functions can generate a link
+    # back to the record in the TRLN view without the controller context.
+    def link_to_record
+      TrlnArgon::Engine.configuration.root_url.chomp('/') +
+        Rails.application.routes.url_helpers.trln_solr_document_path(self)
+    end
+  end
+end

--- a/spec/lib/trln_argon/solr_document_spec.rb
+++ b/spec/lib/trln_argon/solr_document_spec.rb
@@ -51,6 +51,20 @@ describe TrlnArgon::SolrDocument do
     end
   end
 
+  describe 'link_to_record' do
+    let(:link_document) do
+      SolrDocumentTestClass.new(
+        id: 'UNCb6060605'
+      )
+    end
+
+    it 'returns a link to the record' do
+      expect(link_document.link_to_record).to eq(
+        'https://discovery.trln.org/catalog/UNCb6060605'
+      )
+    end
+  end
+
   describe 'names' do
     let(:names_document) do
       SolrDocumentTestClass.new(

--- a/spec/lib/trln_argon/trln_solr_document_spec.rb
+++ b/spec/lib/trln_argon/trln_solr_document_spec.rb
@@ -1,0 +1,20 @@
+describe TrlnArgon::TrlnSolrDocument do
+  class TrlnSolrDocumentTestClass
+    include Blacklight::Solr::Document
+    include TrlnArgon::TrlnSolrDocument
+  end
+
+  describe 'link_to_record' do
+    let(:link_document) do
+      TrlnSolrDocumentTestClass.new(
+        id: 'UNCb6060605'
+      )
+    end
+
+    it 'returns a link to the record' do
+      expect(link_document.link_to_record).to eq(
+        'https://discovery.trln.org/trln/UNCb6060605'
+      )
+    end
+  end
+end

--- a/trln_argon.gemspec
+++ b/trln_argon.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'openurl', '~>1.0'
   s.add_dependency 'font-awesome-rails', '~> 4.7'
   s.add_dependency 'bootstrap-select-rails', '~> 1.12'
-  s.add_dependency 'chosen-rails', '~> 1.8.7'
+  s.add_dependency 'trln-chosen-rails', '~> 1.8.7'
   s.add_dependency 'coffee-rails', '~> 4.2'
   s.add_dependency 'rsolr', '>= 1.0', '< 3'
   s.add_dependency 'addressable', '~> 2.5'


### PR DESCRIPTION
A few changes here:

1. Fix for the reload code mappings task.
2. Uses trln-chosen-rails to remove dependency on sass
3. The bulk of the changes here do some setup so that we can fix record linking from the trln export (email, ris) functions. The generator will do the set up in a new application, but existing applications will require a little bit of surgery to apply the fix. These changes are completely backwards compatible so no local changes are required -- you just won't get the fix. (I will document this in draft release notes.)