### PR TITLE
Don't show broken google preview image when preview unavailable

### DIFF
--- a/app/assets/javascripts/trln_argon/google_books_preview.js.erb
+++ b/app/assets/javascripts/trln_argon/google_books_preview.js.erb
@@ -34,9 +34,11 @@ Blacklight.onLoad(function() {
                     if (! link ) {
                         return;
                     }
-                    $('#google-books-preview-image').each(function () {
-                        if (this.src.length == 0) {
-                            $('#google-books-preview-image').attr({ src: "<%= asset_path('trln_argon/google_books_preview.png') %>" });
+                    $('#google-books').each(function () {
+                        if ($(this).find('img').length == 0) {
+                            $('#google-books').append("<img id='google-books-preview-image' " +
+                                "alt='Google Preview' " +
+                                "src='<%= asset_path('trln_argon/google_books_preview.png') %>'>");
                             $("#google-books-preview-image").after(
                                 '<a href=' + link +
                                 ' target="_blank"> Preview this title via Google Book Search </a>');

--- a/app/views/catalog/_show_google_book_preview.html.erb
+++ b/app/views/catalog/_show_google_book_preview.html.erb
@@ -1,3 +1,2 @@
 <div id="google-books" data-isbn="<%= @document.isbn_number %>">
-	<img id="google-books-preview-image" alt="Google Preview">
 </div>

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '1.3.3'.freeze
+  VERSION = '1.3.4'.freeze
 end


### PR DESCRIPTION
On UNC's catalog, bibliographic records that don't have a google preview available show a broken image icon + img alt text on Chrome. Example: https://catalog.lib.unc.edu/catalog/UNCb7612483

(Vs records w/ a google preview available, which shows the correct google preview image w/ preview link: https://catalog.lib.unc.edu/catalog/UNCb8394840)

We think this was introduced when the img alt text was added in [this commit from May 7](https://github.com/trln/trln_argon/commit/4afbce076f981fe7d95d500c6b30209d14db16d1#diff-17a1061b8b4f40f9898a9084e0321fe4).

This PR removes the img element by default from the view partial, and adds in img w/ alt text via ajax if google preview available.