### PR TITLE
Add Solr rel score, debug features.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
+  TargetRubyVersion: 2.3
   Exclude:
     - '.internal_test_app/**/*'
     - 'Gemfile'
@@ -81,3 +82,7 @@ RSpec/VerifiedDoubles:
 
 RSpec/MessageSpies:
   EnforcedStyle: receive
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+

--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -242,7 +242,7 @@ body {
 
 }
 
-#startOverLink, #editSearchLink {
+#startOverLink, #editSearchLink, #solrRequestLink {
   margin-right: 1em;
 }
 
@@ -474,6 +474,18 @@ dd[aria-expanded=true] .expandable-content-controls .show-control.less {
       padding-left: 2em;
       color: #767676;
     }
+}
+
+.solr-debug-info {
+  color: #f09905;
+  font-size: 125%;
+  a {
+    color: #f09905;
+    text-decoration: underline;
+  }
+  .solr-debug-info-details {
+    font-weight: bold;
+  }
 }
 
 .index-document-metadata {

--- a/app/models/default_local_search_builder.rb
+++ b/app/models/default_local_search_builder.rb
@@ -7,5 +7,6 @@ class DefaultLocalSearchBuilder < SearchBuilder
                                      only_home_facets
                                      author_boost
                                      subjects_boost
-                                     add_document_ids_query]
+                                     add_document_ids_query
+                                     add_solr_debug]
 end

--- a/app/models/default_trln_search_builder.rb
+++ b/app/models/default_trln_search_builder.rb
@@ -7,5 +7,6 @@ class DefaultTrlnSearchBuilder < SearchBuilder
                                      only_home_facets
                                      author_boost
                                      subjects_boost
-                                     add_document_ids_query]
+                                     add_document_ids_query
+                                     add_solr_debug]
 end

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,6 +1,9 @@
 <% if query_has_constraints? %>
   <div id="appliedParams" class="clearfix constraints-container" role="navigation" aria-label="Search Constraints">
     <div class="pull-left">
+      <%= solr_query_request %>
+    </div>
+    <div class="pull-left">
       <%= link_to t('blacklight.search.start_over_html'), start_over_path, :class => "catalog_startOverLink btn btn-primary btn-sm", :id=>"startOverLink" %>
     </div>
     <div class="pull-left">
@@ -9,4 +12,5 @@
     <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
     <%= render_constraints(params) %>
   </div>
+
 <% end %>

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -243,3 +243,8 @@ en:
 
         bookmarks:
             constraint_label: "Document IDs"
+
+        debug_info:
+            solr_query_request: "Solr Request"
+            solr_document_score: "Relevance Score: "
+            solr_document_request: "Solr Document"

--- a/lib/trln_argon/argon_search_builder.rb
+++ b/lib/trln_argon/argon_search_builder.rb
@@ -1,5 +1,5 @@
 require 'trln_argon/argon_search_builder/add_query_to_solr'
-require 'trln_argon/argon_search_builder/add_solr_debug_query'
+require 'trln_argon/argon_search_builder/add_solr_debug_info'
 require 'trln_argon/argon_search_builder/author_boost'
 require 'trln_argon/argon_search_builder/disable_boolean_for_all_caps'
 require 'trln_argon/argon_search_builder/count_only'
@@ -15,7 +15,7 @@ module TrlnArgon
   # local record filtering, etc.
   module ArgonSearchBuilder
     include AddQueryToSolr
-    include AddSolrDebugQuery
+    include AddSolrDebugInfo
     include AuthorBoost
     include DisableBooleanForAllCaps
     include CountOnly

--- a/lib/trln_argon/argon_search_builder.rb
+++ b/lib/trln_argon/argon_search_builder.rb
@@ -1,4 +1,5 @@
 require 'trln_argon/argon_search_builder/add_query_to_solr'
+require 'trln_argon/argon_search_builder/add_solr_debug_query'
 require 'trln_argon/argon_search_builder/author_boost'
 require 'trln_argon/argon_search_builder/disable_boolean_for_all_caps'
 require 'trln_argon/argon_search_builder/count_only'
@@ -14,6 +15,7 @@ module TrlnArgon
   # local record filtering, etc.
   module ArgonSearchBuilder
     include AddQueryToSolr
+    include AddSolrDebugQuery
     include AuthorBoost
     include DisableBooleanForAllCaps
     include CountOnly

--- a/lib/trln_argon/argon_search_builder/add_solr_debug_info.rb
+++ b/lib/trln_argon/argon_search_builder/add_solr_debug_info.rb
@@ -1,9 +1,8 @@
 module TrlnArgon
   module ArgonSearchBuilder
-    module AddSolrDebugQuery
+    module AddSolrDebugInfo
       def add_solr_debug(solr_parameters)
         return unless blacklight_params[:debug] == 'true'
-        solr_parameters[:debug] = 'true'
         solr_parameters[:fl] = '*,score'
       end
     end

--- a/lib/trln_argon/argon_search_builder/add_solr_debug_query.rb
+++ b/lib/trln_argon/argon_search_builder/add_solr_debug_query.rb
@@ -1,0 +1,11 @@
+module TrlnArgon
+  module ArgonSearchBuilder
+    module AddSolrDebugQuery
+      def add_solr_debug(solr_parameters)
+        return unless blacklight_params[:debug] == 'true'
+        solr_parameters[:debug] = 'true'
+        solr_parameters[:fl] = '*,score'
+      end
+    end
+  end
+end

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -236,6 +236,13 @@ module TrlnArgon
           lf_components[0..-2].join('_') => [[lf_components[-1]], ':']
         }
 
+        # solr debug fields to be displayed in the index (search results) view
+        # when debug=true is present in the request.
+        config.add_index_field TrlnArgon::Fields::SCORE.to_s,
+                               helper_method: :relevance_score
+        config.add_index_field TrlnArgon::Fields::ID.to_s,
+                               helper_method: :solr_document_request
+
         # solr fields to be displayed in the index (search results) view
         #   The ordering of the field names is the order of the display
         config.add_index_field TrlnArgon::Fields::STATEMENT_OF_RESPONSIBILITY.to_s,
@@ -354,6 +361,8 @@ module TrlnArgon
         config.add_show_field TrlnArgon::Fields::UPC.to_s,
                               label: TrlnArgon::Fields::UPC.label
 
+        config.add_show_sub_header_field TrlnArgon::Fields::ID.to_s,
+                                         helper_method: :solr_document_request
         config.add_show_sub_header_field TrlnArgon::Fields::STATEMENT_OF_RESPONSIBILITY.to_s,
                                          accessor: :statement_of_responsibility
         config.add_show_sub_header_field TrlnArgon::Fields::CREATOR_MAIN.to_s,

--- a/lib/trln_argon/solr_field_defaults.yml
+++ b/lib/trln_argon/solr_field_defaults.yml
@@ -387,11 +387,15 @@ RESOURCE_TYPE_FACET:
   label:
     en: Resource Type
 ROLLUP_ID:
-  solr_field: rollup_id
+  solr_field: :rollup_id
   label:
     en: Rollup ID
+SCORE:
+  solr_field: :score
+  label:
+    en: score
 SECONDARY_URLS:
-  solr_field: secondary_urls
+  solr_field: :secondary_urls
   label:
     en: Links
 SERIES_STATEMENT:

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '1.3.8'.freeze
+  VERSION = '1.3.9'.freeze
 end

--- a/lib/trln_argon/view_helpers/debug_info_helper.rb
+++ b/lib/trln_argon/view_helpers/debug_info_helper.rb
@@ -1,0 +1,85 @@
+module TrlnArgon
+  module ViewHelpers
+    module DebugInfoHelper
+      def solr_query_request
+        return unless display_debug_info?
+        link_to I18n.t('trln_argon.debug_info.solr_query_request'),
+                solr_query_request_url,
+                class: 'catalog_solrRequestLink btn btn-warning btn-sm',
+                id: 'solrRequestLink',
+                target: '_blank'
+      end
+
+      def solr_document_request(options = {})
+        return unless display_debug_info?
+        content_tag :span, class: solr_debug_info_class do
+          "#{options.fetch(:document, '')&.id}: #{document_debug_links(options)}".html_safe
+        end
+      end
+
+      def relevance_score(options = {})
+        return unless display_debug_info?
+        content_tag :span, class: solr_debug_info_class do
+          "#{I18n.t('trln_argon.debug_info.solr_document_score')}#{relevance_score_span(options)}".html_safe
+        end
+      end
+
+      private
+
+      def document_debug_links(options)
+        content_tag :span, class: solr_debug_info_details_class do
+          link_to_solr_document_response(options).html_safe
+        end
+      end
+
+      def link_to_solr_document_response(options)
+        solr_doc_url = "#{solr_document_request_url}#{options.fetch(:document, '')&.id}".html_safe
+        link_to(I18n.t('trln_argon.debug_info.solr_document_request'), solr_doc_url, target: '_blank')
+      end
+
+      def relevance_score_span(options)
+        content_tag :span, class: solr_debug_info_details_class do
+          number_with_delimiter(options.fetch(:value, ['unknown']).first, delimiter: ',')
+        end
+      end
+
+      def solr_document_request_url
+        "#{[solr_url, solr_document_only_path].join('/')}?id="
+      end
+
+      def solr_query_request_url
+        "#{[solr_url, solr_query_path].join('/')}?#{solr_query_params}"
+      end
+
+      def solr_url
+        Blacklight.connection_config.fetch(:url, nil).chomp('/')
+      end
+
+      def solr_query_params
+        @response.fetch('responseHeader', [])
+                 .fetch('params', {})
+                 .to_query
+      end
+
+      def solr_document_only_path
+        blacklight_config.document_solr_path
+      end
+
+      def solr_query_path
+        blacklight_config.solr_path
+      end
+
+      def solr_debug_info_class
+        'solr-debug-info'
+      end
+
+      def solr_debug_info_details_class
+        'solr-debug-info-details'
+      end
+
+      def display_debug_info?
+        params.fetch(:debug, false) == 'true'
+      end
+    end
+  end
+end

--- a/lib/trln_argon/view_helpers/trln_argon_helper.rb
+++ b/lib/trln_argon/view_helpers/trln_argon_helper.rb
@@ -1,4 +1,5 @@
 require 'trln_argon/view_helpers/advanced_search_helper'
+require 'trln_argon/view_helpers/debug_info_helper'
 require 'trln_argon/view_helpers/document_export_helper'
 require 'trln_argon/view_helpers/facets_helper'
 require 'trln_argon/view_helpers/items_section_helper'
@@ -16,6 +17,7 @@ module TrlnArgon
     # in app/helpers/trln_argon_helper.rb
     module TrlnArgonHelper
       include AdvancedSearchHelper
+      include DebugInfoHelper
       include DocumentExportHelper
       include FacetsHelper
       include ItemsSectionHelper
@@ -81,10 +83,9 @@ module TrlnArgon
 
       def call_number_display(item)
         return '' if item.nil? || item.empty? || !item.respond_to?(:fetch)
-        r = item.fetch('call_no', '')
-        r << " #{item['vol']}" if item.key?('vol')
-        r << " #{item['copy_no']}" if item.key?('copy_no')
-        r
+        [item.fetch('call_no', nil),
+         item.fetch('vol', nil),
+         item.fetch('copy_no', nil)].compact.join(' ')
       end
 
       def item_notes_display(item)

--- a/spec/fixtures/files/debug/response_headers.yml
+++ b/spec/fixtures/files/debug/response_headers.yml
@@ -1,0 +1,47 @@
+---
+:responseHeader:
+  :zkConnected: true
+  :status: 0
+  :QTime: 503
+  :params:
+    :facet.query[]:
+    - date_cataloged_dt:[NOW-7DAY/DAY TO NOW]
+    - date_cataloged_dt:[NOW-1MONTH/DAY TO NOW]
+    - date_cataloged_dt:[NOW-3MONTH/DAY TO NOW]
+    :f.available_f.facet.limit: '11'
+    :f.date_cataloged_dt.facet.limit: '11'
+    :f.location_hierarchy_f.facet.sort: count
+    :fl: "*,score"
+    :f.subject_chronological_f.facet.limit: '11'
+    :f.subject_genre_f.facet.limit: '11'
+    :fq: institution_f:unc
+    :f.subject_geographic_f.facet.limit: '11'
+    :stats: 'true'
+    :f.physical_media_f.facet.limit: '11'
+    :wt: json
+    :stats.field: publication_year_isort
+    :f.lcc_callnum_classification_f.facet.limit: '4501'
+    :debug: 'true'
+    :sort: score desc, publication_year_isort desc, title_sort_ssort_single asc
+    :rows: '20'
+    :q: milton
+    :f.language_f.facet.limit: '11'
+    :f.location_hierarchy_f.facet.limit: '201'
+    :facet.field[]:
+    - access_type_f
+    - available_f
+    - "{!ex=rollup}location_hierarchy_f"
+    - resource_type_f
+    - physical_media_f
+    - subject_topical_f
+    - lcc_callnum_classification_f
+    - language_f
+    - "{!ex=publication_year_isort_single}publication_year_isort"
+    - author_facet_f
+    - subject_genre_f
+    - subject_geographic_f
+    - subject_chronological_f
+    :f.author_facet_f.facet.limit: '11'
+    :f.resource_type_f.facet.limit: '11'
+    :f.subject_topical_f.facet.limit: '11'
+    :facet: 'true'

--- a/spec/lib/trln_argon/argon_search_builder_spec.rb
+++ b/spec/lib/trln_argon/argon_search_builder_spec.rb
@@ -360,4 +360,20 @@ describe TrlnArgon::ArgonSearchBuilder do
       end
     end
   end
+
+  describe '#add_solr_debug' do
+    before { builder_with_params.add_solr_debug(solr_parameters) }
+
+    let(:builder_with_params) do
+      search_builder.with(debug: 'true')
+    end
+
+    it 'adds the solr debug parameter' do
+      expect(solr_parameters[:debug]).to eq('true')
+    end
+
+    it 'adds the score to the fl paramater' do
+      expect(solr_parameters[:fl]).to eq('*,score')
+    end
+  end
 end

--- a/spec/lib/trln_argon/argon_search_builder_spec.rb
+++ b/spec/lib/trln_argon/argon_search_builder_spec.rb
@@ -368,10 +368,6 @@ describe TrlnArgon::ArgonSearchBuilder do
       search_builder.with(debug: 'true')
     end
 
-    it 'adds the solr debug parameter' do
-      expect(solr_parameters[:debug]).to eq('true')
-    end
-
     it 'adds the score to the fl paramater' do
       expect(solr_parameters[:fl]).to eq('*,score')
     end

--- a/spec/lib/trln_argon/controller_override_spec.rb
+++ b/spec/lib/trln_argon/controller_override_spec.rb
@@ -206,6 +206,10 @@ describe TrlnArgon::ControllerOverride do
     it 'sets the creator main field' do
       expect(override_config.index_fields).to have_key('creator_main_a')
     end
+
+    it 'sets the debug info' do
+      expect(override_config.index_fields).to have_key('id')
+    end
   end
 
   describe 'show fields' do
@@ -450,6 +454,10 @@ describe TrlnArgon::ControllerOverride do
 
     it 'sets the creator main field' do
       expect(override_config.show_sub_header_fields).to have_key('creator_main_a')
+    end
+
+    it 'sets the debug info' do
+      expect(override_config.show_sub_header_fields).to have_key('id')
     end
   end
 

--- a/spec/lib/trln_argon/search_builder/default_local_search_builder_spec.rb
+++ b/spec/lib/trln_argon/search_builder/default_local_search_builder_spec.rb
@@ -33,5 +33,9 @@ describe DefaultLocalSearchBuilder do
     it 'adds the author boost method to the processor chain' do
       expect(obj.processor_chain).to include(:author_boost)
     end
+
+    it 'adds the solr debug method to the processor chain' do
+      expect(obj.processor_chain).to include(:add_solr_debug)
+    end
   end
 end

--- a/spec/lib/trln_argon/search_builder/default_trln_search_builder_spec.rb
+++ b/spec/lib/trln_argon/search_builder/default_trln_search_builder_spec.rb
@@ -33,5 +33,9 @@ describe DefaultTrlnSearchBuilder do
     it 'adds the author boost method to the processor chain' do
       expect(obj.processor_chain).to include(:author_boost)
     end
+
+    it 'adds the solr debug method to the processor chain' do
+      expect(obj.processor_chain).to include(:add_solr_debug)
+    end
   end
 end

--- a/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
@@ -212,6 +212,66 @@ describe TrlnArgonHelper, type: :helper do
   end
 
   ########################
+  # DebugInfoHelper
+  ########################
+
+  describe 'DebugInfoHelper' do
+    let(:solr_params) do
+      YAML.safe_load(file_fixture('debug/response_headers.yml').read, [Symbol])
+    end
+
+    let(:document) do
+      SolrDocument.new(YAML.safe_load(file_fixture('documents/DUKE002952265.yml').read).first)
+    end
+
+    let(:options) do
+      { document: document }
+    end
+
+    before do
+      allow(helper).to receive(:solr_query_params).and_return(solr_params)
+      allow(helper).to receive(:solr_document_only_path).and_return('/document')
+      allow(helper).to receive(:solr_query_path).and_return('https://query.discovery.trln.org/trlnbib/')
+    end
+
+    describe '#solr_document_request' do
+      it 'when debug enabled it generates a link to the solr request' do
+        allow(helper).to receive(:params).and_return(debug: 'true')
+        expect(helper.solr_query_request).to be_truthy
+      end
+
+      it 'when debug disabled it does not generate a link to the solr request' do
+        allow(helper).to receive(:params).and_return({})
+        expect(helper.solr_query_request).to be_falsey
+      end
+    end
+
+    describe '#solr_document_request' do
+      it 'when debug enabled it generates a link to the solr document request' do
+        allow(helper).to receive(:params).and_return(debug: 'true')
+        expect(helper.solr_document_request(options)).to be_truthy
+      end
+
+      it 'when debug disabled it does not generate a link to the solr document request' do
+        allow(helper).to receive(:params).and_return({})
+        expect(helper.solr_document_request(options)).to be_falsey
+      end
+    end
+
+    describe '#relevance_score' do
+      it 'when debug enabled it generates a displayable relevance score' do
+        allow(helper).to receive(:params).and_return(debug: 'true')
+        expect(helper.relevance_score(options)).to be_truthy
+      end
+
+      it 'when debug disabled it does not generate a displayable relevance score' do
+        allow(helper).to receive(:params).and_return({})
+        expect(helper.relevance_score(options)).to be_falsey
+      end
+    end
+  end
+
+  ########################
   # ItemsSectionHelper
   ########################
 


### PR DESCRIPTION
Adding `debug=true` to the request adds links to the solr request, solr documents, and the relevance scores:
![Screen Shot 2020-02-10 at 3 31 19 PM](https://user-images.githubusercontent.com/458247/74187422-8015e280-4c1a-11ea-8730-cb109879f5c2.png)
