### PR TITLE
TD-119 -- Add WorldCat results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.6
+
+EXPOSE 3000
+
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
+
+WORKDIR /opt/trln_argon
+
+RUN bundle install && bundle exec rake engine_cart:prepare
+
+CMD cd /opt/trln_argon && ./docker-start.sh
+#bundle exec rake engine_cart:server['-b 0.0.0.0']
+
+

--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ FACET_PAGING_LIMIT: 50
 # value; a git repository containing the mappings is checked
 # out to the directory
 ARGON_CODE_MAPPINGS_DIR: #{File.join(Rails.root, 'config', 'mappings')
+
+# The following are collectively required to perform queries
+# against the Worldcat API and link to the results, which is typically
+# done when there are no results.
+
+# Wording and styling of the results can be adjusted via editing the
+# key `trln_argon.search.zero_results.{worldcat_href, worldcat_html}`
+# in the locale file and/or editing  the
+# `app/views/catalog/_zero_results.html.erb` template
+
+WORLDCAT_URL: # URL for localized instance of Worldcat
+WORLDCAT_API_URL: # https://www.worldcat.org/webservices/catalog/search/sru
+WORLDCAT_API_KEY: # (institution-specific key for accessing above API)
 ```
 
 ### Changing Styles

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -2,8 +2,4 @@
 
 module CatalogHelper
   include TrlnArgon::ViewHelpers::CatalogHelperBehavior
-
-  def worldcat_search_available?
-    WorldcatQueryService.available?
-  end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -2,4 +2,8 @@
 
 module CatalogHelper
   include TrlnArgon::ViewHelpers::CatalogHelperBehavior
+
+  def worldcat_search_available?
+    WorldcatQueryService.available?
+  end
 end

--- a/app/helpers/trln_worldcat_helper.rb
+++ b/app/helpers/trln_worldcat_helper.rb
@@ -1,0 +1,21 @@
+module TrlnWorldcatHelper
+  include ApplicationHelper
+
+  def worldcat_search_available?
+    WorldcatQueryService.available?
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def worldcat_query
+    old_wq = WorldcatQueryService.new(session[:worldcat]) unless session[:worldcat].nil?
+    new_wq = WorldcatQueryService.new(@current_search_session)
+    return old_wq if old_wq && old_wq.id == new_wq.id
+
+    session[:worldcat] = nil
+    session[:worldcat] = new_wq.to_h
+    session[:worldcat][:count] = new_wq.count
+    session[:worldcat][:query_url] = new_wq.query_url
+    new_wq
+  end
+  # rubocop:enable Metrics/AbcSize
+end

--- a/app/services/worldcat_query_service.rb
+++ b/app/services/worldcat_query_service.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+#  rubocop:disable Metrics/ClassLength
+# Service for querying worldcat
+class WorldcatQueryService
+  extend TrlnArgon::HTTPFetch
+  attr_reader :id, :query_params
+
+  DEFAULTS = {
+    params: {
+      maximumRecords: '1',
+      wskey: ENV['WORLDCAT_API_KEY'],
+      servicelevel: 'full'
+    }
+  }.freeze
+
+  QUERY_MAP = {
+    author: 'au',
+    isbn: 'bn',
+    issn: 'in',
+    isbn_issn: 'bn', # need to combine with issn'(bn or in)' #needs testing
+    all_fields: 'kw',
+    oclc: 'no',
+    publisher: 'pb',
+    subject: 'su',
+    title: 'ti',
+    q: 'kw'
+    # year: 'yr' # too complicated to support year range now
+  }.freeze
+
+  LINK_MAP = {
+    author: 'au',
+    isbn: 'bn',
+    issn: 'n2',
+    isbn_issn: 'bn', # same as above
+    all_fields: 'kw',
+    oclc: 'no',
+    publisher: 'pb',
+    subject: 'su',
+    title: 'ti',
+    q: 'kw'
+    # year: 'yr' # same as above
+  }.freeze
+
+  def self.available?
+    %w[WORLDCAT_URL WORLDCAT_API_URL WORLDCAT_API_KEY].all? do |k|
+      ENV.include?(k)
+    end
+  end
+
+  def initialize(search_session)
+    if search_session.is_a?(Hash)
+      @id = search_session.fetch(:id, nil)
+      @query_params = search_session.fetch(:query_params, nil)
+      @count = search_session.fetch(:count, nil)
+      @query_url = search_session.fetch(:query_url, nil)
+    else
+      @id = search_session.id
+      @query_params = search_session.query_params
+    end
+  end
+
+  def query_url
+    @query_url ||= search_worldcat_path
+  end
+
+  def to_h
+    { id: @id, query_params: @query_params, count: @count, query_url: @query_url }
+  end
+
+  def worldcat_base_url
+    ENV['WORLDCAT_URL']
+  end
+
+  def count
+    @count ||= fetch_count
+  end
+
+  def search_worldcat_path
+    query = build_string('link')
+    return worldcat_base_url if query.nil? || query.empty?
+
+    worldcat_base_url + 'search?queryString=' + query
+  end
+
+  # Retrieves number of results from a worldcat query
+  # @param params hash
+  def fetch_count
+    query = build_string('query')
+    return '' if query.nil? || query.empty?
+
+    uri = URI.parse(ENV['WORLDCAT_API_URL'])
+    prepared_query = { query: query }.merge(DEFAULTS[:params])
+    uri.query = URI.encode_www_form(prepared_query)
+    doc = Nokogiri::XML.parse(self.class.do_get(uri).body)
+    count = doc.search('numberOfRecords').text
+    return '' if count == '0' || count.nil? || count.empty?
+
+    count
+  rescue StandardError => e
+    Rails.logger.warn("unable to fetch data at #{uri}")
+    Rails.logger.warn(e.backtrace.join("\n"))
+    ''
+  end
+
+  def map_field(type = 'query', field = 'q', exact = true)
+    field_type = type.upcase + '_MAP'
+    return '' if self.class.const_get(field_type)[:"#{field}"].nil?
+
+    if type == 'query'
+      modifier = exact ? ' = ' : ' all '
+      prepend = type == 'query' ? 'srw.' : ''
+      placeholder = '"%s"'
+    else
+      modifier = exact ? '=' : ':'
+      prepend = ''
+      placeholder = '%s'
+    end
+    prepend + self.class.const_get(field_type)[:"#{field}"] + modifier + placeholder
+  end
+
+  private
+
+  def strip_params(params)
+    return '' if params.nil?
+
+    params.reject! { |_k, v| v.nil? || v.empty? || !v.instance_of?(String) }
+    params.each_with_object({}) { |(k, v), h| h[k] = tokenize(v); }
+  end
+
+  def tokenize(query)
+    query&.scan(/("[^"]+"|[^\s"][\w\s]+[^\s"])/)&.flatten
+  end
+
+  def build_string(type = 'query')
+    params = strip_params(@query_params)
+    return '' if params.nil? || params.empty?
+
+    joiner = @query_params[:op] || 'AND'
+    fields = []
+    params.each do |k, v|
+      next if v.empty?
+
+      if v.respond_to?('each')
+        v.each do |sub|
+          fields << if /^"[^"]+"$/.match?(sub)
+                      map_field(type, k, true) % sub[1..-2]
+                    else
+                      map_field(type, k, false) % sub
+                    end
+        end
+      else
+        fields << map_field(type, k, false) % v # don't think this gets called
+      end
+    end
+    fields.reject(&:empty?).join(" #{joiner} ") unless fields.nil? || fields.empty?
+    # TODO: does not handle + or - modifiers nor manual AND OR NOT in query fields in search
+  end
+end
+#  rubocop:enable Metrics/ClassLength

--- a/app/services/worldcat_query_service.rb
+++ b/app/services/worldcat_query_service.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
-#  rubocop:disable Metrics/ClassLength
-# Service for querying worldcat
+# rubocop has waaay too many false positives, and this is a
+# tricky class to refactor
+
+# rubocop:disable all
+# Service for querying worldcat based on Blacklight search
 class WorldcatQueryService
   extend TrlnArgon::HTTPFetch
   attr_reader :id, :query_params
@@ -132,6 +135,7 @@ class WorldcatQueryService
     query&.scan(/("[^"]+"|[^\s"][\w\s]+[^\s"])/)&.flatten
   end
 
+
   def build_string(type = 'query')
     params = strip_params(@query_params)
     return '' if params.nil? || params.empty?
@@ -157,4 +161,4 @@ class WorldcatQueryService
     # TODO: does not handle + or - modifiers nor manual AND OR NOT in query fields in search
   end
 end
-#  rubocop:enable Metrics/ClassLength
+#  rubocop:enable all

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -22,6 +22,14 @@
 
     <ul class="lead">
 
+      <% if params[:q] and worldcat_search_available? %>
+        <% wcqs = worldcat_query %>
+        <li class='no-results-worldcat-search'><%= t('trln_argon.search.zero_results.worldcat_html',
+            href: link_to(raw(t('trln_argon.search.zero_results.worldcat_href',
+            count: wcqs.count)),
+            wcqs.query_url)) %></li>
+      <% end %>
+
       <!-- ARTICLE SEARCH -->
       <% if params[:q] %>
         <li>
@@ -40,6 +48,7 @@
                       url_for(search_state.params_for_search(search_field: blacklight_config.default_search_field.key)) %>
         </li>
       <% end %>
+
 
       <!-- CONTACT US -->
       <li>

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -161,6 +161,9 @@ en:
                 contact_us_href: 'Contact library staff'
                 remove_filters_href: 'Try removing your search filters'
                 remove_filters_html: '%{href} to see more results.'
+                worldcat_href: '<span>View %{count} results at libraries worldwide</span>'
+                worldcat_html: '%{href}'
+          
 
             results:
               location: 'At the Library'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+---
+services:
+  argon:
+    build: .
+    ports:
+      - '3000:3000'
+    network: host
+    volumes:
+      - ./:/opt/trln_argon:Z
+

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# since wer're running in a container, generally
+# engine_cart won't have the chance to clean up after itself
+# and this pid file will straggle, preventing startup
+
+rm -f .internal_test_app/tmp/pids/server.pid 
+
+bundle exec rake engine_cart:server['-b 0.0.0.0']

--- a/lib/trln_argon.rb
+++ b/lib/trln_argon.rb
@@ -21,4 +21,5 @@ module TrlnArgon
   autoload :TrlnSolrDocument, 'trln_argon/trln_solr_document'
   autoload :User, 'trln_argon/user.rb'
   autoload :ViewHelpers, 'trln_argon/view_helpers'
+  autoload :HTTPFetch, 'trln_argon/http_fetch.rb'
 end

--- a/lib/trln_argon/http_fetch.rb
+++ b/lib/trln_argon/http_fetch.rb
@@ -3,25 +3,31 @@
 require 'net/http'
 
 # encapsulates common HTTP operations
-module TrlnArgon::HTTPFetch
-  def do_get(url)
-    uri = URI(url)
-    use_ssl = uri.scheme == 'https'
-    Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
-      http.request(Net::HTTP::Get.new(uri))
+module TrlnArgon
+  module HTTPFetch
+    def do_get(url)
+      uri = URI(url)
+      use_ssl = uri.scheme == 'https'
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+        http.request(Net::HTTP::Get.new(uri))
+      end
+    rescue StandardError => e
+      Rails.logger.error("Unable to fetch content from #{uri}: #{e}")
+      raise e
     end
-  rescue StandardError => e
-    Rails.logger.error("Unable to fetch content from #{uri}: #{e}")
-    raise e
-  end
 
-  def post_form(url, params)
-    uri = URI(url)
-    use_ssl = uri.scheme == 'https'
-    req = Net::HTTP::Post.new(uri)
-    req.set_form_data(params)
-    Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
-      http.request(req)
+    def post_form(url, params)
+      uri = URI(url)
+      use_ssl = uri.scheme == 'https'
+      req = Net::HTTP::Post.new(uri)
+      req.set_form_data(params)
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+        http.request(req)
+      end
+    end
+
+    def fetch_xml(url)
+      Nokogiri::XML.parse(do_get(url).body)
     end
   end
 end

--- a/lib/trln_argon/http_fetch.rb
+++ b/lib/trln_argon/http_fetch.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'net/http'
+
+# encapsulates common HTTP operations
+module TrlnArgon::HTTPFetch
+  def do_get(url)
+    uri = URI(url)
+    use_ssl = uri.scheme == 'https'
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+      http.request(Net::HTTP::Get.new(uri))
+    end
+  rescue StandardError => e
+    Rails.logger.error("Unable to fetch content from #{uri}: #{e}")
+    raise e
+  end
+
+  def post_form(url, params)
+    uri = URI(url)
+    use_ssl = uri.scheme == 'https'
+    req = Net::HTTP::Post.new(uri)
+    req.set_form_data(params)
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: use_ssl) do |http|
+      http.request(req)
+    end
+  end
+end

--- a/lib/trln_argon/version.rb
+++ b/lib/trln_argon/version.rb
@@ -1,3 +1,3 @@
 module TrlnArgon
-  VERSION = '1.3.26'.freeze
+  VERSION = '1.3.27'.freeze
 end


### PR DESCRIPTION
When there are no results, perform a query against the WorldCat API and show a link (with count) to the local institution's WorldCat page with the search results.  Requires additional configuration in `local_env.yml`

(adds some support for running the application under `engine_cart` in a Docker container) 