### PR TITLE
Restore advanced search link

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -1784,3 +1784,8 @@ div[aria-expanded=true] .expandable-content-controls .show-control.less {
   margin-right: 5px;
 }
 
+.advanced-search {
+    display: flex;
+    align-items: center;
+    padding-left: 1em;
+}

--- a/app/components/trln_argon/search_bar_component.html.erb
+++ b/app/components/trln_argon/search_bar_component.html.erb
@@ -1,0 +1,39 @@
+<%= form_tag @url, method: @method, class: @classes.join(' '), role: 'search', 'aria-label' => scoped_t('submit') do %>
+  <%= render_hash_as_hidden_fields(@params) %>
+  <% if @search_fields.length > 1 %>
+    <label for="search_field" class="sr-only visually-hidden"><%= scoped_t('search_field.label') %></label>
+  <% end %>
+  <div class="input-group">
+    <%= prepend %>
+
+    <% if @search_fields.length > 1 %>
+        <%= select_tag(:search_field,
+                       options_for_select(@search_fields, h(@search_field)),
+                       title: scoped_t('search_field.title'),
+                       id: "#{@prefix}search_field",
+                       class: "custom-select form-select search-field") %>
+    <% elsif @search_fields.length == 1 %>
+      <%= hidden_field_tag :search_field, @search_fields.first.last %>
+    <% end %>
+
+    <label for="<%= @prefix %><%= @query_param %>" class="sr-only visually-hidden"><%= scoped_t('search.label') %></label>
+    <%= text_field_tag @query_param, @q, placeholder: scoped_t('search.placeholder'), class: "search-q q form-control rounded-#{@search_fields.length > 1 ? '0' : 'left'}", id: "#{@prefix}q", autocomplete: autocomplete_path.present? ? "off" : "", autofocus: @autofocus, data: { autocomplete_enabled: autocomplete_path.present?, autocomplete_path: autocomplete_path }  %>
+
+    <span class="input-group-append">
+      <%= append %>
+
+      <button type="submit" class="btn btn-primary search-btn" id="<%= @prefix %>search">
+        <span class="submit-search-text"><%= scoped_t('submit') %></span>
+        <%= blacklight_icon :search, aria_hidden: true %>
+      </button>
+    </span>
+
+<% if presenter.advanced_search_enabled? %>
+
+    <div class="advanced-search">
+  <%= link_to t('blacklight.advanced_search.more_options'), @advanced_search_url, class: 'advanced_search'%>
+    </div>
+<% end %>
+  </div>
+<% end %>
+

--- a/app/components/trln_argon/search_bar_component.rb
+++ b/app/components/trln_argon/search_bar_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+#
+module TrlnArgon
+  class SearchBarComponent < Blacklight::SearchBarComponent
+  end
+end

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,0 +1,7 @@
+<%= render(TrlnArgon::SearchBarComponent.new(
+      url: search_action_url,
+      advanced_search_url: search_action_url(action: 'advanced_search'),
+      params: search_state.params_for_search.except(:qt),
+      search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
+      presenter: presenter,
+      autocomplete_path: search_action_path(action: :suggest))) %>

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -1,6 +1,9 @@
 en:
 
+    # BL7 advanced search uses new path
     blacklight:
+        advanced_search:
+          more_options: Advanced Search
 
         home:
 

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -104,6 +104,8 @@ module TrlnArgon
 
         # default advanced config values
         config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
+        # BL7
+        config.advanced_search.enabled = true
         config.advanced_search[:url_key] ||= 'advanced'
         config.advanced_search[:form_facet_partial] ||= 'advanced_search_facets_as_select'
         config.advanced_search[:form_solr_parameters] ||= {


### PR DESCRIPTION
A sample pull request that shows how to override a Blacklight ViewComponent to customize the output.

First, you need to find out what's displaying the part of the page you want to change. I usually end up looking for some telltale text or element class in trln_argon or blacklight source unitl I find the culprit.

If the part of the page is rendered by a ViewComponent (looks like `render(Blacklight::SomeComponent)` then, if you can't find some other way of getting the desired output (many bits of text are configurable by finding the right keys in `config/locales/trln_argon.en.yml` -- changes to HTML structure, even if it's just a class or two, probably need the full override:
 1. find the component in `(blacklight dir)/app/components/blacklight/component_name.rb` (the ruby code) and the template in the same directory and same base name, but `.html.erb` as the extension.  Copy both of these to `app/components/trln_argon/(filename)`
 2. find the erb template or partial in the blacklight codebase that uses the component.  Copy that to the same place in the argon directory.  Edit the name of the component `s/^Blacklight::/TrlnArgon::/`
 3. edit the component ruby file but make sure the component is in the `TrlnArgon` namespace and inherits from the original Blacklight component.  Usually you wil want to remove all the code, unless you need to change some of the behavior.
 4. edit the component's template
 5. (if necessary) edit CSS