### PR TITLE
Enable spellcheck

### DIFF
--- a/app/components/trln_argon/response/spellcheck_component.rb
+++ b/app/components/trln_argon/response/spellcheck_component.rb
@@ -1,0 +1,17 @@
+module TrlnArgon
+  module Response
+    # Render spellcheck results for a search query
+    class SpellcheckComponent < Blacklight::Response::SpellcheckComponent
+
+    private
+
+      def options_from_response(response)
+        if response&.spelling&.collation
+          response.spelling.collation
+        elsif response&.spelling&.words
+          response.spelling.words
+        end
+      end
+    end
+  end
+end

--- a/app/views/catalog/_did_you_mean.html.erb
+++ b/app/views/catalog/_did_you_mean.html.erb
@@ -1,6 +1,3 @@
-<% if @response.total <= spell_check_max && !@response.spelling.collation.nil? && @response.spelling.collation.any? %>
-    <div id="spell">
-     <h4 class="suggest"><em><%= t('blacklight.did_you_mean', :options => safe_join(@response.spelling.collation.map { |collation| link_to_query(collation) }, " #{t('blacklight.or')} ")).html_safe %></em></h4>
-  </div>
-<% end %>
+<%= render(TrlnArgon::Response::SpellcheckComponent.new(response: @response)) %>
+
 


### PR DESCRIPTION
The default [options_from_response](https://github.com/projectblacklight/blacklight/blob/v7.24.0/app/components/blacklight/response/spellcheck_component.rb#L29) needs to be overridden because there is a bug related to the @options variable in [spellcheck_component.html.erb](https://github.com/projectblacklight/blacklight/blob/v7.24.0/app/components/blacklight/response/spellcheck_component.html.erb). The @options variable looks like this [[A,B]] but it should be just a single array so the map method can produce the correct results.