### PR TITLE
comment out the 'Blacklight::SavedSearches' line

### DIFF
--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SavedSearchesController < ApplicationController
-  include Blacklight::SavedSearches
+  # include Blacklight::SavedSearches
 
   helper BlacklightAdvancedSearch::RenderConstraintsOverride
 end


### PR DESCRIPTION
Remove (comment out) the class no longer available in Blacklight 7