### PR TITLE
change rendering of document metadata

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,7 +47,7 @@ Metrics/CyclomaticComplexity:
   Exclude:
     - 'lib/trln_argon/view_helpers/catalog_helper_behavior.rb'
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
   Exclude:
     - 'lib/trln_argon/controller_override.rb'

--- a/app/components/trln_argon/metadata_header_field_layout_component.html.erb
+++ b/app/components/trln_argon/metadata_header_field_layout_component.html.erb
@@ -1,3 +1,3 @@
-<li class="<%= @key  %>">
+<li class="index-metadata <%= @key  %>">
   <%= value %>
 </li>

--- a/app/components/trln_argon/metadata_header_field_layout_component.rb
+++ b/app/components/trln_argon/metadata_header_field_layout_component.rb
@@ -2,7 +2,9 @@ module TrlnArgon
   class MetadataHeaderFieldLayoutComponent < Blacklight::MetadataFieldLayoutComponent
     renders_one :value
     def render?
-      value.present?
+      return false if value&.to_s.blank?
+
+      value.present? && !value.blank?
     end
   end
 end

--- a/app/components/trln_argon/metadata_header_field_layout_component.rb
+++ b/app/components/trln_argon/metadata_header_field_layout_component.rb
@@ -2,9 +2,9 @@ module TrlnArgon
   class MetadataHeaderFieldLayoutComponent < Blacklight::MetadataFieldLayoutComponent
     renders_one :value
     def render?
-      return false if value&.to_s.blank?
-
-      value.present? && !value.blank?
+      # value is actually a ViewComponent::SlotV2 and is probably
+      # not nil? 
+      !(value&.to_s.blank?)
     end
   end
 end

--- a/app/components/trln_argon/metadata_header_field_layout_component.rb
+++ b/app/components/trln_argon/metadata_header_field_layout_component.rb
@@ -1,10 +1,14 @@
 module TrlnArgon
   class MetadataHeaderFieldLayoutComponent < Blacklight::MetadataFieldLayoutComponent
     renders_one :value
+
+    # rubocop:disable Style/RedundantParentheses
     def render?
       # value is actually a ViewComponent::SlotV2 and is probably
-      # not nil? 
+      # not nil?
+      # Rubocop lies, I find this clearer
       !(value&.to_s.blank?)
     end
+    # rubocop:enable Style/RedundantParentheses
   end
 end


### PR DESCRIPTION
Adds back .index-metadata class on author/imprint etc. metadata
displayed below document title on result and full record pages.

Somewhat experimentally, does not render an element when the associated
metadata is not present.