### PR TITLE
Fixes display of item/location info, resolves TD-1140:

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -1189,33 +1189,28 @@ h1, h2, h3, h4, h5 {
   margin-bottom: 2em;
   overflow: hidden;
   border-radius: 0 0 4px 4px;
-  padding: 10px;
-
-
+  padding: 1em 1.5em 1em 1.5em;
 
   .items-spacer {
     height: 2em;
   }
 
   .item {
+    padding-top: .5em;
     margin: .25em 0 .25em 0;
     /*padding-bottom: 1em;*/
     overflow: hidden;
-  }
+    border-bottom: 1px solid #e3e3e3;
 
-  .item:nth-child(n+1):before,
-  .loc-narrow-banner:before {
-    display: block;
-    content: '';
-    border-top: 1px solid #e3e3e3;
-    padding-top: 10px;
-    margin: 0 15px 0 15px;
+    &:last-of-type {
+      border-bottom: none;
+    }
+
   }
 
   .has-summary .item:nth-child(1):before {
     border-top: none;
   }
-
 
 
   .institution-availability .item:nth-child(n+1):before {
@@ -1224,18 +1219,20 @@ h1, h2, h3, h4, h5 {
 
   .location-narrow-group {
     background: rgba(0,0,0,.03);
-    margin-left: 4px;
-    margin-right: 4px;
     width: 100%;
-    padding: 0;
-    margin-bottom: 0;
-    margin-top: 5px;
-    padding-top: 7px;
-    padding-bottom: 5px;
-    padding-left: 30px;
-    padding-right: 15px;
     border: 1px solid rgba(0,0,0,.05);
+    margin: 1em .75em 0 .75em;
+    padding: .5em 0 .5em 0;
+
+    .call-number-wrapper,
+    .summary-wrapper {
+      dl {
+        margin-bottom: 0;
+      }
+    }
   }
+
+
 
 
 
@@ -1297,23 +1294,17 @@ h1, h2, h3, h4, h5 {
     }
   }
 
-
-
-  .call-number-wrapper {
-    float: left;
-  }
-
   .url-note-wrapper {
     margin-top:10px;
   }
 
-  .call-number-label,
-  .status-label,
-  .summary-label,
-  .latest-received-label,
-  .item-note-label,
-  .holding-note-label,
-  .url-note-label {
+  .call-number-badge,
+  .status-badge,
+  .summary-badge,
+  .latest-received-badge,
+  .item-note-badge,
+  .holding-note-badge,
+  .url-note-badge {
     background: #e5e5e5;
     color: #444;
     border: 1px solid #ddd;
@@ -1322,12 +1313,8 @@ h1, h2, h3, h4, h5 {
     margin-right: .25em;
   }
 
-  .location-narrow-group .label {
+  .location-narrow-group .badge {
     background: rgba(255,255,255,.9);
-  }
-
-  .status-wrapper {
-    float: left;
   }
 
   .summary-text,
@@ -1376,8 +1363,35 @@ h1, h2, h3, h4, h5 {
 
 #documents .items {
   overflow: visible;
-  /*.item { overflow: visible;}*/
+  margin-right: 1em;
 }
+
+#document .items,
+#documents .items {
+
+  dl {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  dt {
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 0 0 7em;
+    margin-right: .25em;
+  }
+
+  dd {
+    width: calc(100% - 7.75em);
+    margin-bottom: 0;
+    margin-right: .5em;
+    flex: 1 1 calc(100% - 7.75em);
+  }
+
+}
+
 
 @include media-breakpoint-up(md) {
   #document #holdings .items {
@@ -1406,39 +1420,6 @@ h1, h2, h3, h4, h5 {
   }
 
 }
-
-
-
-@include media-breakpoint-up(sm) {
-
-  #documents .items {
-    margin-right: 1em;
-  }
-
-  #document .items,
-  #documents .items {
-
-    dt {
-      float: left;
-      clear: left;
-      text-align: right;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      width: 7em;
-    }
-
-    /* dd { margin-left: 7.1em; } */
-
-  }
-
-  /* #documents .items .institution-availability {
-    dt { width: 4em; }
-    dd { margin-left: 4.5em; }
-  } */
-
-}
-
 
 .blacklight.thumbnail {
   margin-bottom: 0;

--- a/app/views/catalog/_index_items_latest_received.html.erb
+++ b/app/views/catalog/_index_items_latest_received.html.erb
@@ -1,9 +1,9 @@
 <% lr_text, lr_url = latest_received(document, item_data) %>
 <% unless lr_text.blank? %>
 <div class="<%= latest_received_wrapper_class %>">
-      <dl class="row">
-        <dt class="col-sm-3"><span class='latest-received-label badge badge-info'><%= t('trln_argon.show.label.latest_received') %></span></dt>
-        <dd class="col-sm-9">
+      <dl>
+        <dt><span class='latest-received-badge badge badge-info'><%= t('trln_argon.show.badge.latest_received') %></span></dt>
+        <dd>
         	<span class='latest-received'>
         	<% if lr_url.blank? %>
         		<%= lr_text %>

--- a/app/views/catalog/_items_section.html.erb
+++ b/app/views/catalog/_items_section.html.erb
@@ -34,11 +34,11 @@
 
             <% # ---ITEMS WRAPPER --- %>
 
-              <div class="item-group-display col-md-12 <%= display_holdings_summaries?(item_data) ? 'has-summary' : '' %>" id="<%= document.id %>-<%= loc_n %>-<%= document_index %>-preview">
+              <div class="item-group-display col-lg-12 <%= display_holdings_summaries?(item_data) ? 'has-summary' : '' %>" id="<%= document.id %>-<%= loc_n %>-<%= document_index %>-preview">
 
                 <% item_data['items'].first(num_display_items).each do |item| %>
 
-                  <div class="col-md-12 item <%= loc_n %> <%= loc_b %>" data-item-barcode="<%= get_item_id(item) %>">
+                  <div class="row no-gutters item <%= loc_n %> <%= loc_b %>" data-item-barcode="<%= get_item_id(item) %>">
 
                     <%= render partial: "items_section_item", locals: { document: document, item: item, loc_b: loc_b, loc_n: loc_n } %>
 
@@ -50,13 +50,13 @@
 
               <% if item_data['items'].size > num_display_items %>
 
-                <div class='item-group-display col-md-12 collapse' id="item-container-<%=document.id %>-<%= loc_n %>-<%= document_index %>">
+                <div class='item-group-display col-lg-12 collapse' id="item-container-<%=document.id %>-<%= loc_n %>-<%= document_index %>">
 
                   <% item_data['items'].each_with_index do |item, i| %>
 
                     <% next if i < num_display_items %>
 
-                    <div class="col-md-12 item <%= loc_n %> <%= loc_b %>" data-item-barcode="<%= get_item_id(item) %>">
+                    <div class="row no-gutters item <%= loc_n %> <%= loc_b %>" data-item-barcode="<%= get_item_id(item) %>">
 
                       <%= render partial: "items_section_item", locals: { document: document, item: item, loc_b: loc_b, loc_n: loc_n } %>
 
@@ -66,7 +66,7 @@
 
                 </div>
 
-                <div class="col-md-12">
+                <div class="col-lg-12">
                   <div class="items-toggle">
 
                     <a href="javascript:void(0);" class="expander btn btn-sm btn-info shower" data-toggle='collapse' data-target='<%= "#item-container-#{document.id}-#{loc_n}-#{document_index}" %>' aria-expanded='false' aria-controls='<%= "item-container-#{document.id}-#{loc_n}-#{document_index}" %>'>

--- a/app/views/catalog/_items_section_item.html.erb
+++ b/app/views/catalog/_items_section_item.html.erb
@@ -1,16 +1,16 @@
 <% # --- ITEM --- %>
 
   <div class="<%= call_number_wrapper_class(action: action_name) %>">
-    <dl class="row">
-    <dt class="col-sm-3"><span class='call-number-label badge badge-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
-    <dd class="col-sm-9"><span class='call-number'><%= call_number_display(item) %></span> <%= render partial: 'location_link', locals: { document: document, loc_b: loc_b, loc_n: loc_n, item: item } %></dd>
+    <dl>
+    <dt><span class='call-number-badge badge badge-info'><%= t('trln_argon.show.badge.call_number') %></span></dt>
+    <dd><span class='call-number'><%= call_number_display(item) %></span> <%= render partial: 'location_link', locals: { document: document, loc_b: loc_b, loc_n: loc_n, item: item } %></dd>
     </dl>
   </div>
 
   <div class="<%= status_wrapper_class(action: action_name) %> status-wrapper" <%= assign_item_id_as_id(item) %>>
-    <dl class="row">
-      <dt class="col-sm-3"><span class='status-label badge badge-info'><%= t('trln_argon.show.label.status') %></span></dt>
-      <dd class="col-sm-9">
+    <dl>
+      <dt><span class='status-badge badge badge-info'><%= t('trln_argon.show.badge.status') %></span></dt>
+      <dd>
        <% available_class = item_availability_display(item) %>
        <% due_date = item_due_date(item) %>
        <span class="<%= available_class %>">
@@ -26,9 +26,9 @@
 <% if item_notes_display(item).present? %>
 
   <div class="<%= item_note_wrapper_class({ action: action_name, item_length: item_notes_display(item).length }) %> item-note-wrapper">
-    <dl class="row">
-      <dt class="col-sm-1"><span class='item-note-label badge badge-info'><%= t('trln_argon.show.label.item_note') %></span></dt>
-      <dd class="col-sm-11"><%= item_notes_display(item) %></dd>
+    <dl>
+      <dt><span class='item-note-badge badge badge-info'><%= t('trln_argon.show.badge.item_note') %></span></dt>
+      <dd><%= item_notes_display(item) %></dd>
     </dl>
   </div>
 

--- a/app/views/catalog/_items_section_summary.html.erb
+++ b/app/views/catalog/_items_section_summary.html.erb
@@ -15,9 +15,9 @@
         <% if h.fetch('call_no', '').present? %>
 
           <div class="<%= call_number_wrapper_class %>">
-            <dl class="row">
-              <dt class="col-sm-3"><span class='call-number-label badge badge-info'><%= t('trln_argon.show.label.call_number') %></span></dt>
-              <dd class="col-sm-9"><span class='call-number'><%= h['call_no'] %></span></dd>
+            <dl>
+              <dt><span class='call-number-badge badge badge-info'><%= t('trln_argon.show.badge.call_number') %></span></dt>
+              <dd><span class='call-number'><%= h['call_no'] %></span></dd>
             </dl>
           </div>
 
@@ -28,9 +28,9 @@
         <% if h.fetch('summary', '').present? %>
 
           <div class="<%= holdings_summary_wrapper_class %>">
-            <dl class="row" id="item-summary-<%= loc_b %>-<%= loc_n %>-<%= document.id %>">
-              <dt class="col-sm-2"><span class='summary-label badge badge-info'><%= t('trln_argon.show.label.summary') %></span></dt>
-              <dd class="col-sm-10">
+            <dl class="row no-gutters" id="item-summary-<%= loc_b %>-<%= loc_n %>-<%= document.id %>">
+              <dt><span class='summary-badge badge badge-info'><%= t('trln_argon.show.badge.summary') %></span></dt>
+              <dd>
 
                 <div class="summary-text-wrapper">
                     <span class="summary-text"><%= h['summary'].gsub(' ', '&nbsp;').html_safe %></span>
@@ -54,9 +54,9 @@
 
           <div class="<%= holdings_note_class %>">
 
-            <dl class="row">
-              <dt class="col-sm-1"><span class='holding-note-label badge badge-info'><%= t('trln_argon.show.label.holding_note') %></span></dt>
-              <dd class="col-sm-11"><%= [*h['notes']].join("; "); %></dd>
+            <dl>
+              <dt><span class='holding-note-badge badge badge-info'><%= t('trln_argon.show.badge.holding_note') %></span></dt>
+              <dd><%= [*h['notes']].join("; "); %></dd>
             </dl>
 
           </div>

--- a/app/views/catalog/_url_note.html.erb
+++ b/app/views/catalog/_url_note.html.erb
@@ -1,8 +1,8 @@
 <% if url_hash[:note].present? %>
   <div class="<%= url_note_wrapper_class %>">
-    <dl class="row">
-      <dt class="col-sm-2"><span class='url-note-label badge badge-info'><%= t('trln_argon.show.label.url_note') %></span></dt>
-      <dd class="col-sm-10"><span class='url-note'><%= url_hash[:note] %></dd>
+    <dl>
+      <dt><span class='url-note-badge badge badge-info'><%= t('trln_argon.show.badge.url_note') %></span></dt>
+      <dd><span class='url-note'><%= url_hash[:note] %></dd>
     </dl>
   </div>
 <% end %>

--- a/app/views/trln/_index_items_default.html.erb
+++ b/app/views/trln/_index_items_default.html.erb
@@ -19,9 +19,9 @@
           <div class="row">
 
             <div class="<%= availability_class %>">
-              <dl class="row">
-                <dt class="col-sm-3"><span class='status-label badge badge-info'><%= t('trln_argon.show.label.status') %></span></dt>
-                <dd class="col-sm-9">
+              <dl>
+                <dt><span class='status-badge badge badge-info'><%= t('trln_argon.show.badge.status') %></span></dt>
+                <dd>
                   <span class="<%= binary_availability_span_class(document: local_doc) %>">
                     <%= local_doc.present? ? local_doc.availability : 'Available' %>
                   </span>

--- a/config/locales/trln_argon.en.yml
+++ b/config/locales/trln_argon.en.yml
@@ -194,7 +194,7 @@ en:
                 metadata: "Other details"
                 expanded_links: "Online"
 
-            label:
+            badge:
                 summary: "Summary"
                 call_number: "Call Number"
                 status: "Status"

--- a/lib/trln_argon/view_helpers/items_section_helper.rb
+++ b/lib/trln_argon/view_helpers/items_section_helper.rb
@@ -2,27 +2,27 @@ module TrlnArgon
   module ViewHelpers
     module ItemsSectionHelper
       def items_spacer_class
-        'items-spacer col-md-12'
+        'items-spacer col-lg-12'
       end
 
       def items_wrapper_class
-        'items-wrapper items-section-index col-md-12'
+        'items-wrapper items-section-index col-lg-12'
       end
 
       def item_class
-        'item col-md-12'
+        'item col-lg-12'
       end
 
       def availability_class
-        'available col-md-5'
+        'available col-lg-5'
       end
 
       def location_header_class
-        'location-header col-md-12'
+        'location-header col-lg-12'
       end
 
       def institution_location_header_class
-        'institution location-header col-md-12'
+        'institution location-header col-lg-12'
       end
 
       def location_narrow_group_class
@@ -30,11 +30,11 @@ module TrlnArgon
       end
 
       def holdings_summary_wrapper_class
-        'col-sm-12 summary-wrapper'
+        'col-lg-12 col-sm-12 summary-wrapper'
       end
 
       def holdings_note_class
-        'holding-note col-md-12'
+        'holding-note col-lg-12'
       end
 
       def url_note_wrapper_class
@@ -68,19 +68,19 @@ module TrlnArgon
       # nb displayed by default next to status
       # column numbers for col-md-# should add up to 12
       def call_number_wrapper_class(_options = {})
-        'col-md-5 col-sm-12 call-number-wrapper'
+        'col-lg-5 col-sm-12 call-number-wrapper'
       end
 
       def status_wrapper_class(_options = {})
-        'col-md-7 col-sm-12'
+        'col-lg-7 col-sm-12'
       end
 
       def item_note_wrapper_class(_options = {})
-        'col-md-12'
+        'col-lg-12'
       end
 
       def latest_received_wrapper_class(_opts = {})
-        'col-md5 col-sm-12 latest-received-wrapper'
+        'col-lg-5 col-sm-12 latest-received-wrapper'
       end
 
       def display_holdings_summaries?(options = {})

--- a/lib/trln_argon/view_helpers/show_view_helper.rb
+++ b/lib/trln_argon/view_helpers/show_view_helper.rb
@@ -25,7 +25,7 @@ module TrlnArgon
       end
 
       def show_main_content_partials_class
-        'col-md-10'
+        'col-md-12'
       end
 
       def show_tools_class

--- a/spec/fixtures/files/hathitrust/hathitrust_response_expectation.yml
+++ b/spec/fixtures/files/hathitrust/hathitrust_response_expectation.yml
@@ -5,4 +5,4 @@ oclc10089569: |2
         <li><a class="link-type-fulltext link-open-access" target="_blank" href="https://catalog.hathitrust.org/Record/100502996"><i class="fa fa-external-link" aria-hidden="true"></i>Full text available via HathiTrust</a></li>
       </ul>
     </div>
-    <div class="items-spacer col-md-12"></div>
+    <div class="items-spacer col-lg-12"></div>

--- a/spec/fixtures/files/internet_archive/internet_archive_response_expectation.yml
+++ b/spec/fixtures/files/internet_archive/internet_archive_response_expectation.yml
@@ -5,4 +5,4 @@ internet-archive-id-publiclawsresol00nort: |2
         <li><a class="link-type-fulltext link-open-access" target="_blank" href="https://archive.org/search.php?query=identifier%3A%28publiclawsresol00nort%20OR%20publiclawsres00nort%20OR%20publiclawsresolu00nort%20OR%20publiclawsreso00nort%29&sort=publicdate"><i class="fa fa-external-link" aria-hidden="true"></i>Full text available via Internet Archive</a></li>
       </ul>
     </div>
-    <div class="items-spacer col-md-12"></div>
+    <div class="items-spacer col-lg-12"></div>

--- a/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
@@ -284,7 +284,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#items_spacer_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.items_spacer_class).to(
-        eq('items-spacer col-md-12')
+        eq('items-spacer col-lg-12')
       )
     end
   end
@@ -292,7 +292,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#items_wrapper_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.items_wrapper_class).to(
-        eq('items-wrapper items-section-index col-md-12')
+        eq('items-wrapper items-section-index col-lg-12')
       )
     end
   end
@@ -300,7 +300,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#item_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.item_class).to(
-        eq('item col-md-12')
+        eq('item col-lg-12')
       )
     end
   end
@@ -308,7 +308,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#availability_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.availability_class).to(
-        eq('available col-md-5')
+        eq('available col-lg-5')
       )
     end
   end
@@ -316,7 +316,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#location_header_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.location_header_class).to(
-        eq('location-header col-md-12')
+        eq('location-header col-lg-12')
       )
     end
   end
@@ -324,7 +324,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#institution_location_header_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.institution_location_header_class).to(
-        eq('institution location-header col-md-12')
+        eq('institution location-header col-lg-12')
       )
     end
   end
@@ -340,7 +340,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#holdings_summary_wrapper_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.holdings_summary_wrapper_class).to(
-        eq('col-sm-12 summary-wrapper')
+        eq('col-lg-12 col-sm-12 summary-wrapper')
       )
     end
   end
@@ -348,7 +348,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#holdings_note_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.holdings_note_class).to(
-        eq('holding-note col-md-12')
+        eq('holding-note col-lg-12')
       )
     end
   end
@@ -438,7 +438,7 @@ describe TrlnArgonHelper, type: :helper do
     context 'show action' do
       it 'returns the HTML class attribute values' do
         expect(helper.call_number_wrapper_class(action: 'show')).to(
-          eq('col-md-5 col-sm-12 call-number-wrapper')
+          eq('col-lg-5 col-sm-12 call-number-wrapper')
         )
       end
     end
@@ -446,7 +446,7 @@ describe TrlnArgonHelper, type: :helper do
     context 'other action' do
       it 'returns the HTML class attribute values' do
         expect(helper.call_number_wrapper_class).to(
-          eq('col-md-5 col-sm-12 call-number-wrapper')
+          eq('col-lg-5 col-sm-12 call-number-wrapper')
         )
       end
     end
@@ -456,14 +456,14 @@ describe TrlnArgonHelper, type: :helper do
     context 'show action' do
       it 'returns the HTML class attribute values' do
         expect(helper.status_wrapper_class(action: 'show')).to(
-          eq('col-md-7 col-sm-12')
+          eq('col-lg-7 col-sm-12')
         )
       end
     end
     context 'other action' do
       it 'returns the HTML class attribute values' do
         expect(helper.status_wrapper_class).to(
-          eq('col-md-7 col-sm-12')
+          eq('col-lg-7 col-sm-12')
         )
       end
     end
@@ -473,21 +473,21 @@ describe TrlnArgonHelper, type: :helper do
     context 'show action and long items' do
       it 'returns the HTML class attribute values' do
         expect(helper.item_note_wrapper_class(action: 'show', item_length: 130)).to(
-          eq('col-md-12')
+          eq('col-lg-12')
         )
       end
     end
     context 'show action short item' do
       it 'returns the HTML class attribute values' do
         expect(helper.item_note_wrapper_class(action: 'show', item_length: 110)).to(
-          eq('col-md-12')
+          eq('col-lg-12')
         )
       end
     end
     context 'all other cases' do
       it 'returns the HTML class attribute values' do
         expect(helper.item_note_wrapper_class).to(
-          eq('col-md-12')
+          eq('col-lg-12')
         )
       end
     end
@@ -1099,7 +1099,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#show_main_content_partials_class' do
     it 'returns the HTML class attribute values' do
       expect(helper.show_main_content_partials_class).to(
-        eq('col-md-10')
+        eq('col-md-12')
       )
     end
   end


### PR DESCRIPTION
- removed column markup from inslide DL
- uses flexbox to align DT and DD elements
- updated wrapper elements to use larger viewport (col-md-12 to col-lg-12) sizes to better work with BS4

![example1](https://user-images.githubusercontent.com/2537019/169894177-e89c9941-669a-4151-ac2b-168a589515ea.png)

![example2](https://user-images.githubusercontent.com/2537019/169894193-8ee7ea60-f405-400e-92b7-cb7282ca2ad6.png)

