### PR TITLE
adding U+FE0E next to right and down arrow characters to keep firefox…

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -721,11 +721,11 @@ div.facet-content { // non-hierarcical facets
   }
 
   li.h-node::before {
-    content: '▶';
+    content: '▶︎';
   }
 
   li.h-node.twiddle-open::before {
-    content: '▼';
+    content: '▼︎';
   }
 
   li.h-leaf::before,


### PR DESCRIPTION
… from rendering as emoji

- see: http://www.unicode-symbol.com/u/FE0E.html

Before:

![before](https://user-images.githubusercontent.com/2537019/170065552-892c7c3c-38c8-4557-a0ec-302b65f1d274.png)


After:

![after](https://user-images.githubusercontent.com/2537019/170065589-0577ea82-00b2-438d-afc8-4cb44995c087.png)
