### PR TITLE
Render advanced search form fields in horizontal orientation optimize…

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -1069,6 +1069,14 @@ h1, h2, h3, h4, h5 {
   line-height: 1.2;
 }
 
+/* BS3 class that was removed in BS4 but we still */
+/* use it. */
+.page-header {
+  padding-bottom: 12px;
+  margin: 40px 0 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
 #documents .document h3.document-title-heading {
   font-size: 1.4em;
   font-weight: 400;
@@ -1781,6 +1789,7 @@ h2.local-filter-heading  {
 /* ======================= */
 
 .twitter-typeahead {
+  z-index: auto;
   .tt-menu {
     max-height: 300px;
     overflow-y: auto;

--- a/app/components/trln_argon/advanced_search_form_component.html.erb
+++ b/app/components/trln_argon/advanced_search_form_component.html.erb
@@ -35,11 +35,12 @@
           <!-- Fetch and display publication year range input if configured. -->
           <% pub_date = blacklight_config.facet_fields[TrlnArgon::Fields::PUBLICATION_YEAR_SORT.to_s] %>
           <% if pub_date.present? %>
-            <div class="form-group advanced-search-facet row">
-              <%= label_tag pub_date.field.parameterize, :class => "col-sm-3 control-label" do %>
+            <div class="form-group row advanced-search-facet">
+              <%= label_tag pub_date.field.parameterize,
+                    class: "col-12 col-sm-6 col-md-3 col-form-label font-weight-bold" do %>
                   <%= pub_date.label %>
               <% end %>
-              <div class="col-sm-9 range_limit">
+              <div class="col-12 col-sm-6 col-md-9 range_limit">
                 <label for="range_publication_year_isort_begin" class="sr-only">Publication date range (starting year)</label>
                 <%= render_range_input(pub_date.field, :begin) %> – 
                 <label for="range_publication_year_isort_end" class="sr-only">Publication date range (ending year)</label>
@@ -47,7 +48,6 @@
               </div>
             </div>
           <% end %>
-
 
         </div>
       </div>

--- a/app/views/advanced/_advanced_search_facets_as_select.html.erb
+++ b/app/views/advanced/_advanced_search_facets_as_select.html.erb
@@ -1,4 +1,10 @@
-<%# alternate version of facets on form that renders using multi-select.
+<!-- NOTE: Override of BL Advanced Search partial so that we can -->
+<!--       render location codes as human readable strings.   -->
+<!-- TODO: Evaluate whether the Blacklight 7+ native advanced -->
+<!--       search might be sufficient enough to retire these  -->
+<!--       custom overrides. -->
+
+<%# Alternate version of facets on form that renders using multi-select.
     Has to copy and paste more code from blacklight than default, making
     it somewhat more fragile. 
     Logic taken from facets_helper_behavior.rb, #render_facet_partials and
@@ -7,23 +13,32 @@
 
 <% facets_from_request(facet_field_names).each do |display_facet| %>
     <% if should_render_facet?(display_facet) %>
-        <div class="form-group advanced-search-facet">
-            <%= label_tag display_facet.name.parameterize, class: "col-sm-3 control-label", id: "#{display_facet.name.parameterize}_label"  do %>
+        <div class="form-group row advanced-search-facet">
+            <%= label_tag display_facet.name.parameterize,
+                  class: 'col-12 col-sm-6 col-md-3 col-form-label font-weight-bold',
+                  id: "#{display_facet.name.parameterize}_label" do %>
                 <%= facet_field_label(display_facet.name) %>
-            <% end %>            
+            <% end %>
 
-            <div class="col-sm-12">
-                <%= content_tag(:select, :multiple => true,                     
-                    :name   => "f_inclusive[#{display_facet.name}][]",
-                    :id     => display_facet.name.parameterize,
-                    :class  => "form-control advanced-search-facet-select") do %>
+            <div class="col-12 col-sm-6 col-md-9">
+                <%= content_tag(:select,
+                      multiple: true,
+                      name: "f_inclusive[#{display_facet.name}][]",
+                      id: display_facet.name.parameterize,
+                      class: 'form-control custom-select advanced-search-facet-select') do %>
                     <% display_facet.items.each do |facet_item| %>
-                        <%= content_tag :option, :value => facet_item.value, :selected => facet_value_checked?(display_facet.name, facet_item.value) do %>
-                            <%= facet_item.label %>&nbsp;&nbsp;(<%= number_with_delimiter facet_item.hits %>)
+                      <%= content_tag :option,
+                          value: facet_item.value,
+                          selected: facet_value_checked?(display_facet.name, facet_item.value) do %>
+                        <% if display_facet.name == TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.to_s %>
+                          <%= location_filter_display(facet_item.label) %>&nbsp;&nbsp;(<%= number_with_delimiter facet_item.hits %>)
+                        <% else %>
+                          <%= facet_item.label %>&nbsp;&nbsp;(<%= number_with_delimiter facet_item.hits %>)
                         <% end %>
+                      <% end %>
                     <% end %>
                 <% end %>
             </div>
-        </div>        
+        </div>
     <% end %>
 <% end %>

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -1,14 +1,16 @@
+<!-- TODO: Evaluate whether the Blacklight 7+ native advanced -->
+<!--       search might be sufficient enough to retire these  -->
+<!--       custom overrides. -->
 <%- search_fields_for_advanced_search.each do |key, field_def| -%>
-  <div class="form-group advanced-search-field">
-      <%= label_tag key, "#{field_def.label }", :class => "col-sm-3 control-label" %>
-      <div class="col-sm-12">
-      	<% if key =~ /^(all_fields|title|author|subject)$/ %>
-          <!-- TODO: autocomplete breaks the field length -->
-          <%#= text_field_tag key, label_tag_default_for(key), :class => 'form-control', :autocomplete => :off, data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: '/:controller/suggest/:category' } %>
-          <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+  <div class="form-group row advanced-search-field">
+      <%= label_tag key, "#{field_def.label }",
+            class: 'col-12 col-sm-6 col-md-3 col-form-label font-weight-bold' %>
+      <div class="col-12 col-sm-6 col-md-9 d-flex">
+        <% if key =~ /^(all_fields|title|author|subject)$/ %>
+          <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control', :autocomplete => :off, data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) } %>
         <% else %>
-          <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
-        <% end %>  
+          <%= text_field_tag key, label_tag_default_for(key), class: 'form-control' %>
+        <% end %>
       </div>
   </div>
 <%- end -%>

--- a/app/views/catalog/advanced_search.html.erb
+++ b/app/views/catalog/advanced_search.html.erb
@@ -4,7 +4,6 @@
 
     <h1 class="advanced page-header">
         <%= t('blacklight_advanced_search.form.title') %>
-        <%= link_to t('blacklight_advanced_search.form.start_over'), @advanced_search_url, :class =>"btn btn-default pull-right advanced-search-start-over" %>
     </h1>
 
     <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,6 @@ TrlnArgon::Engine.routes.draw do
 
   mount BlacklightAdvancedSearch::Engine => '/'
 
-  get 'advanced_trln' => 'advanced_trln#index', as: 'advanced_trln'
   get ':controller/suggest/:category', to: 'catalog#suggest'
   get 'catalog_count_only', to: 'catalog#count_only', as: 'catalog_count_only'
   get 'trln_count_only', to: 'trln#count_only', as: 'trln_count_only'

--- a/lib/trln_argon/view_helpers/advanced_search_helper.rb
+++ b/lib/trln_argon/view_helpers/advanced_search_helper.rb
@@ -6,11 +6,11 @@ module TrlnArgon
       end
 
       def advanced_search_form_class
-        'col-md-8'
+        'col-lg-8'
       end
 
       def advanced_search_help_class
-        'col-md-4'
+        'col-lg-4'
       end
     end
   end

--- a/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
@@ -206,13 +206,13 @@ describe TrlnArgonHelper, type: :helper do
 
     it 'returns the advanced search form HTML class attribute values' do
       expect(helper.advanced_search_form_class).to(
-        eq('col-md-8')
+        eq('col-lg-8')
       )
     end
 
     it 'returns the advanced search help HTML class attribute values' do
       expect(helper.advanced_search_help_class).to(
-        eq('col-md-4')
+        eq('col-lg-4')
       )
     end
   end


### PR DESCRIPTION
…d for responsiveness. Restore autosuggest functionality for advanced search. Lookup Location facet values in advanced search filters. Closes TD-1147, TD-1148, TD-1151.
<img width="1217" alt="Screen Shot 2022-05-24 at 4 29 13 PM" src="https://user-images.githubusercontent.com/3933756/170127558-18c864b1-c740-4177-a218-44e80dd5aada.png">

<img width="826" alt="Screen Shot 2022-05-24 at 4 29 55 PM" src="https://user-images.githubusercontent.com/3933756/170127583-cac91f8f-de59-4048-9035-a428444ff338.png">

