### PR TITLE
Updates CSS to make contracted:after gradient display better, resolve…

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -413,27 +413,27 @@ dd[aria-expanded=true] .expandable-content-controls .show-control.less {
 .contracted-ul {
   position: relative;
   overflow: hidden;
-  margin-bottom: 20px;
-  max-height: 80px;
+  margin-bottom: 1.25em;
+  max-height: 4.25em;
 }
 
-.contracted-ul {
-  max-height: 90px;
-}
+// .contracted-ul {
+//   max-height: 90px;
+// }
 
 .contracted:after {
   content: "";
   text-align: right;
   position: absolute;
   bottom: 0;
-  right: 0;
+  right: 1em;
   width: 70%;
   height: 1.5em;
-  background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
+  background: linear-gradient(to right, rgba(245, 245, 245, 0), rgba(245, 245, 245, 1) 50%);
 }
 
-.summary-text-wrapper.contracted:after {
-  background: linear-gradient(to right, rgba(243, 243, 243, 0), rgba(237, 237, 237, 1) 50%);
+.location-narrow-group .row.contracted:after {
+  background: linear-gradient(to right, rgba(237, 237, 237, 0), rgba(237, 237, 237, 1) 50%);
 }
 
 .show-document,
@@ -1208,7 +1208,7 @@ h1, h2, h3, h4, h5 {
   padding: 1em 1.5em 1em 1.5em;
 
   .items-spacer {
-    height: .5em;
+    height: 1.5em;
   }
 
   .hathi-trust-link {
@@ -1307,7 +1307,7 @@ h1, h2, h3, h4, h5 {
     margin-bottom: .25em;
 
     ~ .location-header {
-      margin-top: 0.5em;
+      margin-top: 2.5em;
     }
 
     h3, h4 {
@@ -1470,13 +1470,19 @@ h1, h2, h3, h4, h5 {
   #document #holdings .items {
     .primary-url { margin-bottom: 0;}
     /*.item { padding-bottom: 0; }*/
-    .location-header ~ .location-header { margin-top: 1.25em; }
+    .location-header ~ .location-header { margin-top: 2.5em; }
   }
 
   // .institution-availability .primary-url {
   //   margin-top: 0;
   // }
 
+}
+
+body.blacklight-trln-index #documents .items {
+  .location-header ~ .location-header {
+    margin-top: 1.25em;
+  }
 }
 
 .blacklight.thumbnail {


### PR DESCRIPTION
…s TD-1155.

(note that this screenshot shows the text being contracted after three lines - we actually have this set to six so I just changed it temporarily to get it to trigger)

![contracted](https://user-images.githubusercontent.com/2537019/170132531-0532657b-a6af-40c3-850d-863f3de938f6.png)

