### PR TITLE
fix mappings for new advanced search URLs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,15 @@ TrlnArgon::Engine.routes.draw do
     resources :healthchecks, path: '/health', action: :index
   end
 
-  mount BlacklightAdvancedSearch::Engine => '/'
-
-  get ':controller/suggest/:category', to: 'catalog#suggest'
+  get 'catalog/suggest/:category', to: 'catalog#suggest'
+  get 'trln/suggest/:category', to: 'trln#suggest'
+  get 'trln/advanced', to: 'trln#advanced_search'
   get 'catalog_count_only', to: 'catalog#count_only', as: 'catalog_count_only'
   get 'trln_count_only', to: 'trln#count_only', as: 'trln_count_only'
   get 'hathitrust/:oclc_numbers', to: 'hathitrust#show', as: 'hathitrust'
   get 'internet_archive/:internet_archive_ids', to: 'internet_archive#show', as: 'internet_archive'
+
+  # redirects for blacklight_advanced_search plugin former URLs
+  get '/advanced', to: redirect('catalog/advanced')
+  get '/advanced_trln', to: redirect('trln/advanced')
 end

--- a/lib/trln_argon/trln_controller_behavior.rb
+++ b/lib/trln_argon/trln_controller_behavior.rb
@@ -58,7 +58,7 @@ module TrlnArgon
       end
 
       def advanced_search_url(options = {})
-        trln_argon.url_for(options.merge(controller: 'advanced_trln', action: 'index'))
+        trln_argon.url_for(options.merge(controller: 'trln', action: 'advanced_search'))
       end
 
       def local_search_button_class

--- a/lib/trln_argon/view_helpers/trln_argon_helper.rb
+++ b/lib/trln_argon/view_helpers/trln_argon_helper.rb
@@ -33,7 +33,7 @@ module TrlnArgon
       end
 
       def advanced_search_url(options = {})
-        blacklight_advanced_search_engine.url_for(options.merge(controller: 'advanced', action: 'index'))
+        url_for(options.merge(controller: 'catalog', action: 'advanced_search'))
       end
 
       def institution_code_to_short_name(options = {})


### PR DESCRIPTION
old: `/advanced`, `/advanced_trln`
new: `/catalog/advanced`, `/trln/advanced`
adds redirects for old=>new
fixes dynamic controller deprecation for suggest URLs