### PR TITLE
btn-default has been renamed to btn-secondary in Bootstrap 4

### DIFF
--- a/app/assets/javascripts/trln_argon/bookmark_share.js
+++ b/app/assets/javascripts/trln_argon/bookmark_share.js
@@ -1,9 +1,9 @@
 // override default bookmark sharing link behavior and instead open modal with copyable link text
 
 $(document).on('click', '#share_bookmarksLink', function( e ){
-  
+
   e.preventDefault();
-  
+
   var bookmarkShareText= $('#share_bookmarksLink').text(); //Share
   var bookmarkNameText= $('#content h2.page-heading').text(); //Bookmarks
   var shareBookmarksText = bookmarkShareText + " " + bookmarkNameText;
@@ -12,7 +12,7 @@ $(document).on('click', '#share_bookmarksLink', function( e ){
 
 
   // create modal
-  $('#content').append('<div class="modal fade" id="bookmark-modal" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button><h4 class="modal-title">' + shareBookmarksText + '</h4></div><div class="modal-body"><p class="help-block">' + shareBookmarksHelperText + '</p><div class="input-group"><input id="sharing-url-holder" type="text" class="form-control" data-autoselect="" value="' + bookmarkShareURL + '" aria-label="' + shareBookmarksText + '" readonly=""><span class="input-group-btn"><button id="copy-to-clipboard" class="btn btn-default" type="button" data-toggle="tooltip" data-placement="bottom" title="Copy to clipboard"><i class="fa fa-clipboard" aria-hidden="true"></i></button></span></div></div><div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal">Close</button></div></div></div></div>'); 
+  $('#content').append('<div class="modal fade" id="bookmark-modal" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button><h4 class="modal-title">' + shareBookmarksText + '</h4></div><div class="modal-body"><p class="help-block">' + shareBookmarksHelperText + '</p><div class="input-group"><input id="sharing-url-holder" type="text" class="form-control" data-autoselect="" value="' + bookmarkShareURL + '" aria-label="' + shareBookmarksText + '" readonly=""><span class="input-group-btn"><button id="copy-to-clipboard" class="btn btn-outline-secondary" type="button" data-toggle="tooltip" data-placement="bottom" title="Copy to clipboard"><i class="fa fa-clipboard" aria-hidden="true"></i></button></span></div></div><div class="modal-footer"><button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Close</button></div></div></div></div>');
 
   // open modal
   $('#bookmark-modal').modal('show');
@@ -43,7 +43,7 @@ $(document).on('click', '#share_bookmarksLink', function( e ){
 
       $('#sharing-url-holder').focus();
       $('#sharing-url-holder').select();
-      
+
       try {
         var successful = document.execCommand('copy');
         var msg = successful ? 'successful' : 'unsuccessful';

--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -39,7 +39,7 @@ a:hover, a:focus {
 
 #facets div.facet-limit-active {
   border-color: $secondary-color !important;
-  
+
   h3.card-header {
     background-color: $secondary-color !important;
     border-color: $secondary-color !important;
@@ -71,7 +71,7 @@ a:hover, a:focus {
     border-color: $primary-color;
 }
 
-#facet-location_hierarchy_f a.remove, 
+#facet-location_hierarchy_f a.remove,
 #facet-lcc_callnum_classification_f a.remove {
   color: $primary-color;
   :hover {
@@ -90,7 +90,7 @@ a:hover, a:focus {
      color: $primary-color;
     :hover {
       color: $not-available-color;
-    } 
+    }
   }
 }
 
@@ -684,7 +684,7 @@ div.facet-content { // non-hierarcical facets
   }
 }
 
-#facet-location_hierarchy_f, 
+#facet-location_hierarchy_f,
 #facet-lcc_callnum_classification_f { // hierarcical facets
 
   ul {
@@ -894,6 +894,16 @@ ul.facet-hierarchy li.h-node.twiddle-open:last-child {
     &.toggle-trln {
       text-align: left;
       margin-left: -2px;
+    }
+
+    .btn-outline-secondary {
+      &:hover,
+      &:not(:disabled):not(.disabled):active,
+      &:focus {
+        color: #333;
+        background-color: #e6e6e6;
+        border-color: #adadad;
+      }
     }
 
   }
@@ -1269,7 +1279,7 @@ h1, h2, h3, h4, h5 {
   }
 
   .institution-availability {
-    
+
     .item {
       display: flex;
       flex-wrap: wrap;
@@ -1304,7 +1314,7 @@ h1, h2, h3, h4, h5 {
         margin-bottom: 0;
       }
     }
-    
+
     .item:nth-child(n+1):before {
       margin: 0 0 0 0;
     }

--- a/app/components/trln_argon/search_bar_component.html.erb
+++ b/app/components/trln_argon/search_bar_component.html.erb
@@ -10,7 +10,7 @@
           <%= select_tag(:search_field,
                        options_for_select(@search_fields, h(@search_field)),
                        #title: scoped_t('search_field.title'),
-                       data: {style: "btn-default search-select"},
+                       data: {style: "btn-outline-secondary search-select"},
                        id: "#{@prefix}search_field",
                        class: "search_field selectpicker") %>
       <% elsif @search_fields.length == 1 %>

--- a/lib/trln_argon/trln_controller_behavior.rb
+++ b/lib/trln_argon/trln_controller_behavior.rb
@@ -62,7 +62,7 @@ module TrlnArgon
       end
 
       def local_search_button_class
-        'btn-default'
+        'btn-outline-secondary'
       end
 
       def trln_search_button_class

--- a/lib/trln_argon/view_helpers/search_scope_toggle_helper.rb
+++ b/lib/trln_argon/view_helpers/search_scope_toggle_helper.rb
@@ -14,7 +14,7 @@ module TrlnArgon
       end
 
       def trln_search_button_class
-        'btn-default'
+        'btn-outline-secondary'
       end
 
       def local_search_button_label_class

--- a/spec/lib/trln_argon/trln_controller_behavior_spec.rb
+++ b/spec/lib/trln_argon/trln_controller_behavior_spec.rb
@@ -31,7 +31,7 @@ describe TrlnArgon::TrlnControllerBehavior do
   describe '#local_search_button_class' do
     it 'sets the search button class' do
       expect(mock_controller.helpers.local_search_button_class).to eq(
-        'btn-default'
+        'btn-outline-secondary'
       )
     end
   end

--- a/spec/lib/trln_argon/view_helpers/search_scope_toggle_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/search_scope_toggle_helper_spec.rb
@@ -19,7 +19,7 @@ describe TrlnArgon::ViewHelpers::SearchScopeToggleHelper, type: :helper do
 
   describe '#trln_search_button_class' do
     it 'returns the expected class' do
-      expect(helper.trln_search_button_class).to eq('btn-default')
+      expect(helper.trln_search_button_class).to eq('btn-outline-secondary')
     end
   end
 


### PR DESCRIPTION
btn-default has been renamed to btn-secondary in BS4. Though, I think we actually want the outlined version, btn-outline-secondary. This PR will update the HTML and styling for any element that used the old btn-default class.

For example, currently the TRLN icon search page looks like this as it's referencing a btn-default class that was removed in BS4
<img width="316" alt="trln-btn-no-outline" src="https://user-images.githubusercontent.com/436691/172454611-e19b2cb0-5384-4d84-b40b-009b84edaaf3.png">

btn-default was renamed to btn-secondary. Unfortunately it causes the TRLN icon to look like this
<img width="305" alt="trln-btn-secondary" src="https://user-images.githubusercontent.com/436691/172454723-48888bba-472d-44b0-bc41-b8f978508c52.png">

I'd argue what we really want is btn-outline-secondary, which gives this
<img width="342" alt="trln-btn-outline-secondary" src="https://user-images.githubusercontent.com/436691/172454860-4cb4ecdc-0b00-46cd-9a15-84173b3f331f.png">

Unfortunately on "hover" and other events we're back to an overly dark button
<img width="299" alt="trln-btn-outline-secondary-hover" src="https://user-images.githubusercontent.com/436691/172454979-aaa3f398-669f-4385-8134-5760c47e61d7.png">

I've added some CSS to lighten the hover et al styling, the result is this
<img width="302" alt="trln-btn-outline-secondary-hover-light" src="https://user-images.githubusercontent.com/436691/172455081-9338dded-a815-4af0-9dc0-ba3cdead63c6.png">
