### PR TITLE
Clicking bookmarks link give a solr error if no bookmarks are present

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -7,12 +7,13 @@ class BookmarksController < CatalogController
   # which is blocked by our Solr configuration, so we need to ensure
   # our requests are done via GET
   # rubocop:disable Layout/LineLength
+  # rubocop:disable Metrics/MethodLength
   def index
     @bookmarks = token_or_current_or_guest_user.bookmarks
     bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }
-    
+
     if bookmark_ids.empty?
-      @response = Blacklight::Solr::Response.new({},{})
+      @response = Blacklight::Solr::Response.new({}, {})
       @document_list = []
     else
       query_params = {
@@ -35,4 +36,5 @@ class BookmarksController < CatalogController
     end
   end
   # rubocop:enable Layout/LineLength
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,6 +1,7 @@
 class BookmarksController < CatalogController
   include Blacklight::Bookmarks
   include TrlnArgon::BookmarksControllerBehavior
+  include BookmarksHelper
 
   # blacklight 7 will try, in default configuration to POST any request
   # which is blocked by our Solr configuration, so we need to ensure
@@ -10,7 +11,7 @@ class BookmarksController < CatalogController
     @bookmarks = token_or_current_or_guest_user.bookmarks
     bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }
     query_params = {
-      q: "id:(#{bookmark_ids.join(' OR ')})",
+      q: bookmarks_query(bookmark_ids),
       defType: 'lucene',
       rows: bookmark_ids.count
     }

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -10,15 +10,20 @@ class BookmarksController < CatalogController
   def index
     @bookmarks = token_or_current_or_guest_user.bookmarks
     bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }
-    query_params = {
-      q: bookmarks_query(bookmark_ids),
-      defType: 'lucene',
-      rows: bookmark_ids.count
-    }
-    # search_service.fetch does this internally (7.25)
-    @response = search_service.repository.search(query_params)
-    @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(@response.documents,
-                                                                           'The @document_list instance variable is now deprecated and will be removed in Blacklight 8.0')
+    
+    if bookmark_ids.empty?
+      @response = Blacklight::Solr::Response.new({},{})
+      @document_list = []
+    else
+      query_params = {
+        q: bookmarks_query(bookmark_ids),
+        defType: 'lucene',
+        rows: bookmark_ids.count
+      }
+      # search_service.fetch does this internally (7.25)
+      @response = search_service.repository.search(query_params)
+      @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(@response.documents, 'The @document_list instance variable is now deprecated and will be removed in Blacklight 8.0')
+    end
 
     respond_to do |format|
       format.html {}

--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -1,5 +1,5 @@
 module BookmarksHelper
   def bookmarks_query(bookmark_ids)
-    bookmark_ids.length > 0 ? "id:(#{bookmark_ids.join(' OR ')})" : ""
+    !bookmark_ids.empty? ? "id:(#{bookmark_ids.join(' OR ')})" : ''
   end
 end

--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -1,0 +1,5 @@
+module BookmarksHelper
+  def bookmarks_query(bookmark_ids)
+    bookmark_ids.length > 0 ? "id:(#{bookmark_ids.join(' OR ')})" : ""
+  end
+end

--- a/spec/helpers/bookmarks_helper_spec.rb
+++ b/spec/helpers/bookmarks_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe BookmarksHelper, type: :helper do
+  describe 'bookmark query generation' do
+    it 'returns empty string if no bookmarks are present' do
+      bookmarks = []
+      expect(helper.bookmarks_query(bookmarks)).to eq('')
+    end
+
+    it 'returns bookmark query if a bookmark is present' do
+      bookmarks = %w[UNCb11138369]
+      expect(helper.bookmarks_query(bookmarks)).to eq('id:(UNCb11138369)')
+    end
+
+    it 'returns an OR seperated bookmark query if multiple bookmarks are present' do
+      bookmarks = %w[UNCb11138369 UNCb9753415 UNCb10553096]
+      expect(helper.bookmarks_query(bookmarks)).to eq('id:(UNCb11138369 OR UNCb9753415 OR UNCb10553096)')
+    end
+  end
+end


### PR DESCRIPTION
When clicking the bookmarks link
<img width="304" alt="empty-bookmarks" src="https://user-images.githubusercontent.com/436691/172461166-fc0a016b-c983-4bf5-aeea-068e68740f93.png">

You get the following error if the user has no items bookmarked
<img width="1120" alt="empty-bookmarks-error" src="https://user-images.githubusercontent.com/436691/172461268-54e5fa5d-6731-43c1-a283-9e158e963059.png">

This PR fixes the solr query to search for an empty string if there are no bookmarks.
Added as a helper as it was easier to add a few tests that way.
