### PR TITLE
remove some deprecation messages

### DIFF
--- a/app/components/trln_argon/search_bar_component.html.erb
+++ b/app/components/trln_argon/search_bar_component.html.erb
@@ -30,7 +30,7 @@
       </span>
     </div>
 
-    <% if search_bar_presenter.advanced_search_enabled? %>
+    <% if advanced_search_enabled? %>
       <div class="advanced-search">
         <%= link_to t('blacklight.advanced_search.more_options'), @advanced_search_url, class: 'advanced_search'%>
       </div>

--- a/app/views/blacklight/hierarchy/_facet_hierarchy.html.erb
+++ b/app/views/blacklight/hierarchy/_facet_hierarchy.html.erb
@@ -1,0 +1,3 @@
+<ul class="facet-hierarchy" role="tree">
+  <%= render_hierarchy(facet_field) %>
+</ul>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,3 +1,3 @@
 <div class="index-document-metadata">
-  <%= render(TrlnArgon::DocumentHeaderMetadataComponent.new(fields: index_presenter(document).field_presenters)) %>
+  <%= render(TrlnArgon::DocumentHeaderMetadataComponent.new(fields: document_presenter(document).field_presenters)) %>
 </div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -18,6 +18,13 @@
 
 <div id='search-navbar' class="navbar-search navbar navbar-light bg-light" role="navigation">
   <div class="<%= container_classes %>">
-    <%= render_search_bar  %>
+    <%= render TrlnArgon::SearchBarComponent.new(
+        url: search_action_url,
+        advanced_search_url: search_action_url(action: 'advanced_search'),
+        params: search_state.params_for_search.except(:qt),
+        search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
+        autocomplete_path: search_action_path(action: :suggest)
+      )
+%>
   </div>
 </div>

--- a/lib/trln_argon/view_helpers/advanced_search_helper.rb
+++ b/lib/trln_argon/view_helpers/advanced_search_helper.rb
@@ -1,6 +1,10 @@
 module TrlnArgon
   module ViewHelpers
     module AdvancedSearchHelper
+      def advanced_search_enabled?
+        configuration.advanced_search.enabled
+      end
+
       def advanced_search_page_class
         'advanced-search-form col-sm-12'
       end

--- a/lib/trln_argon/view_helpers/hierarchy_helper.rb
+++ b/lib/trln_argon/view_helpers/hierarchy_helper.rb
@@ -29,24 +29,26 @@ module TrlnArgon
       #        (and with :partial => 'blacklight/hierarchy/facet_hierarchy')
       # @return [String] html for the facet tree
       def render_hierarchy(bl_facet_field, delim = '_')
-        field_name = bl_facet_field.field
+        Deprecation.silence(Blacklight::HierarchyHelper) do 
+          field_name = bl_facet_field.field
 
-        # NOTE CHANGE: Fetch the sort setting from the facet field config.
-        sort = bl_facet_field.sort || 'index'
+          # NOTE CHANGE: Fetch the sort setting from the facet field config.
+          sort = bl_facet_field.sort || 'index'
 
-        prefix = field_name.gsub("#{delim}#{field_name.split(/#{delim}/).last}", '')
-        facet_tree_for_prefix = facet_tree(prefix)
-        tree = facet_tree_for_prefix ? facet_tree_for_prefix[field_name] : nil
+          prefix = field_name.gsub("#{delim}#{field_name.split(/#{delim}/).last}", '')
+          facet_tree_for_prefix = facet_tree(prefix)
+          tree = facet_tree_for_prefix ? facet_tree_for_prefix[field_name] : nil
 
-        return '' unless tree
+          return '' unless tree
 
-        # NOTE CHANGE: Apply the configured sort option to the first node values.
-        tree = hierarchy_node_sort(tree, sort, field_name)
+          # NOTE CHANGE: Apply the configured sort option to the first node values.
+          tree = hierarchy_node_sort(tree, sort, field_name)
 
-        # NOTE CHANGE: Do not sort keys to preserve current sort.
-        tree.keys.collect do |key|
-          render_facet_hierarchy_item(field_name, tree[key], key, sort)
-        end.join("\n").html_safe
+          # NOTE CHANGE: Do not sort keys to preserve current sort.
+          tree.keys.collect do |key|
+            render_facet_hierarchy_item(field_name, tree[key], key, sort)
+          end.join("\n").html_safe
+        end
       end
 
       def render_facet_hierarchy_item(field_name, data, key, sort)

--- a/lib/trln_argon/view_helpers/hierarchy_helper.rb
+++ b/lib/trln_argon/view_helpers/hierarchy_helper.rb
@@ -29,7 +29,7 @@ module TrlnArgon
       #        (and with :partial => 'blacklight/hierarchy/facet_hierarchy')
       # @return [String] html for the facet tree
       def render_hierarchy(bl_facet_field, delim = '_')
-        Deprecation.silence(Blacklight::HierarchyHelper) do 
+        Deprecation.silence(Blacklight::HierarchyHelper) do
           field_name = bl_facet_field.field
 
           # NOTE CHANGE: Fetch the sort setting from the facet field config.


### PR DESCRIPTION
* Override hierarchical facet display partial from blacklight-hierarchy v4.3.0
but without the deprecation warning (since there is nothing we can do with
it for now).  
* Use various non-deprecated methods and components in favor
of the old deprecated ones 
  * `document_presenter` over `index_presenter`
  * `SearchBarComponent` instead of calling out to `render_search_bar`
* Create a top-level `advanced_search_enabled?` method to avoid calling
deprecated `search_bar_presenter`