### PR TITLE
Replicate recent revisions to BL7 partials in our local custom copies

### DIFF
--- a/app/views/catalog/_document_list.html.erb
+++ b/app/views/catalog/_document_list.html.erb
@@ -1,4 +1,5 @@
 <% # container for all documents in index list view -%>
-<div id="documents" class="documents-<%= document_index_view_type %>" role="main" aria-labelledby="searchResultsLabel">
-  <%= render documents, :as => :document %>
+<% view_config = local_assigns[:view_config] || blacklight_config&.view_config(document_index_view_type) %>
+<div id="documents" class="documents-<%= view_config&.key || document_index_view_type %>" role="main" aria-labelledby="searchResultsLabel">
+  <%= render documents, as: :document, view_config: view_config %>
 </div>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,9 +1,9 @@
 <h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
 
-<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
+<% @page_title = t('blacklight.search.page_title.title', constraints: render_search_to_page_title(params), application_name: application_name) %>
 
 <% content_for(:head) do -%>
-  <%= render_opensearch_response_metadata %>
+  <%= render 'catalog/opensearch_response_metadata', response: @response %>
   <%= rss_feed_link_tag %>
   <%= atom_feed_link_tag %>
   <%= json_api_link_tag %>
@@ -11,14 +11,14 @@
 
 <%= render 'search_header' %>
 
-<h2 class="sr-only" id="searchResultsLabel"><%= t('blacklight.search.search_results') %></h2>
+<h2 class="sr-only visually-hidden" id="searchResultsLabel"><%= t('blacklight.search.search_results') %></h2>
 
 <%- if @response.empty? %>
   <%= render "zero_results" %>
 <%- elsif render_grouped_response? %>
-  <%= render_grouped_document_index %>
+  <%= Deprecation.silence(Blacklight::RenderPartialsHelperBehavior) { render_grouped_document_index } %>
 <%- else %>
-  <%= render_document_index %>
+  <%= render_document_index @response.documents %>
 <%- end %>
 
 <%= render 'results_pagination' %>

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -40,7 +40,7 @@
       <% end %>
 
       <!-- KEYWORD SEARCH INSTEAD -->
-      <% if params[:q] and params[:search_field] and params[:search_field] != blacklight_config.default_search_field.try(:key) %>
+      <%- if params[:q] and params[:search_field] and params[:search_field] != blacklight_config.default_search_field&.key -%>
         <li>
           <%= t 'trln_argon.search.zero_results.search_fields', :search_fields => search_field_label(params) %>
           <%= link_to t('trln_argon.search.zero_results.search_everything',

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -5,4 +5,4 @@
   </div>
 <% end %>
 
-<%= render_document_main_content_partial %>
+<%= render 'show_main_content' %>


### PR DESCRIPTION
These minor revisions (to four files) follow an analysis of the ~30 view partials for which a local customized copy of a core Blacklight file exists in TRLN Argon. It's possible that none of these changes will have an immediately noticeable affect, however these revisions should help us by:
- replacing some deprecated code to reduce log warnings and ease future Blacklight updates
- keeping our customized files as close as possible to core to help us identify significant differences in the future
