### PR TITLE
Replace all remaining Bootstrap 3 classes with BS4 equivalents. Fixes…

### DIFF
--- a/app/assets/javascripts/trln_argon/bookmark_share.js
+++ b/app/assets/javascripts/trln_argon/bookmark_share.js
@@ -5,14 +5,14 @@ $(document).on('click', '#share_bookmarksLink', function( e ){
   e.preventDefault();
 
   var bookmarkShareText= $('#share_bookmarksLink').text(); //Share
-  var bookmarkNameText= $('#content h2.page-heading').text(); //Bookmarks
+  var bookmarkNameText= $('#content h1.page-heading').text(); //Bookmarks
   var shareBookmarksText = bookmarkShareText + " " + bookmarkNameText;
   var shareBookmarksHelperText = "Use this link to " + bookmarkShareText.toLowerCase() + " your " + bookmarkNameText.toLowerCase();
   var bookmarkShareURL = window.location.origin + $('#share_bookmarksLink').attr('href');
 
 
   // create modal
-  $('#content').append('<div class="modal fade" id="bookmark-modal" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button><h4 class="modal-title">' + shareBookmarksText + '</h4></div><div class="modal-body"><p class="help-block">' + shareBookmarksHelperText + '</p><div class="input-group"><input id="sharing-url-holder" type="text" class="form-control" data-autoselect="" value="' + bookmarkShareURL + '" aria-label="' + shareBookmarksText + '" readonly=""><span class="input-group-btn"><button id="copy-to-clipboard" class="btn btn-outline-secondary" type="button" data-toggle="tooltip" data-placement="bottom" title="Copy to clipboard"><i class="fa fa-clipboard" aria-hidden="true"></i></button></span></div></div><div class="modal-footer"><button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Close</button></div></div></div></div>');
+  $('#content').append('<div class="modal fade" id="bookmark-modal" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"><h4 class="modal-title">' + shareBookmarksText + '</h4><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div><div class="modal-body"><p class="form-text">' + shareBookmarksHelperText + '</p><div class="input-group"><input id="sharing-url-holder" type="text" class="form-control" data-autoselect="" value="' + bookmarkShareURL + '" aria-label="' + shareBookmarksText + '" readonly=""><span class="input-group-btn"><button id="copy-to-clipboard" class="btn btn-outline-secondary" type="button" data-toggle="tooltip" data-placement="bottom" title="Copy to clipboard"><i class="fa fa-clipboard" aria-hidden="true"></i></button></span></div></div><div class="modal-footer"><button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Close</button></div></div></div></div>');
 
   // open modal
   $('#bookmark-modal').modal('show');

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= render(TrlnArgon::AdvancedSearchFormComponent.new(
       url: search_action_url,
-      classes: ['advanced', 'form-horizontal'],
+      classes: ['advanced'],
       params: search_state.params_for_search.except(:qt),
       search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
       response: @response

--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -1,11 +1,11 @@
-<div class="sort-buttons pull-left">
-  <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
+<div class="sort-buttons float-left">
+  <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "col-form-label") %>
   <%- sort_fields = active_sort_fields.values.map { |field_config| [sort_field_label(field_config.key), field_config.key] } %>
   <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select") %>
   <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
 </div>
 
-<div class="submit-buttons pull-right">
+<div class="submit-buttons float-right">
   <%= link_to t('blacklight_advanced_search.form.start_over'), @advanced_search_url, :class =>"btn btn-secondary advanced-search-start-over" %>
 
   <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit" %>

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,12 +1,12 @@
 <% if query_has_constraints? %>
   <div id="appliedParams" class="clearfix constraints-container" role="navigation" aria-label="Search Constraints">
-    <div class="pull-left">
+    <div class="float-left">
       <%= solr_query_request %>
     </div>
-    <div class="pull-left">
+    <div class="float-left">
       <%= render(TrlnArgon::StartOverButtonComponent.new(classes: 'catalog_startOverLink btn btn-primary btn-sm')) %>
     </div>
-    <div class="pull-left">
+    <div class="float-left">
       <%= link_to 'Edit Search', advanced_search_url(params.permit!.except(:controller, :action).to_h), :class => "catalog_editSearchLink btn btn-outline-secondary btn-sm", :id=>"editSearchLink" %>
     </div>
     <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,5 +1,5 @@
 <% if current_search_session %>
-  <div class="pull-right search-widgets">
+  <div class="float-right search-widgets">
   	<%= render(TrlnArgon::StartOverButtonComponent.new(classes: 'catalog_startOverLink btn btn-primary')) %>
     <%= link_back_to_catalog class: 'btn btn-outline-secondary' %>
   </div>

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -77,7 +77,7 @@ module TrlnArgon
                                       path: :email_path,
                                       validator: :validate_email_params)
         config.add_show_tools_partial(:sms,
-                                      icon: 'fa fa-sms',
+                                      icon: 'fa fa-commenting',
                                       if: :render_sms_action?,
                                       callback: :sms_action,
                                       path: :sms_path,
@@ -91,13 +91,13 @@ module TrlnArgon
                                       modal: false,
                                       path: :ris_path)
         config.add_show_tools_partial(:refworks,
-                                      icon: 'glyphicon-export',
+                                      icon: 'fa fa-list',
                                       if: :render_refworks_action?,
                                       new_window: true,
                                       modal: false,
                                       path: :refworks_path)
         config.add_show_tools_partial(:share_bookmarks,
-                                      icon: 'glyphicon-share',
+                                      icon: 'fa fa-share',
                                       if: :render_sharebookmarks_action?,
                                       new_window: false,
                                       modal: false,

--- a/lib/trln_argon/view_helpers/trln_argon_helper.rb
+++ b/lib/trln_argon/view_helpers/trln_argon_helper.rb
@@ -131,7 +131,7 @@ module TrlnArgon
 
       def add_icon_to_action_label(document_action_config)
         if document_action_config.key?(:icon)
-          content_tag(:i, '', class: "glyphicon #{document_action_config[:icon]}", 'aria-hidden' => 'true') + ' ' +
+          content_tag(:i, '', class: (document_action_config[:icon]).to_s, 'aria-hidden' => 'true') + ' ' +
             document_action_label(document_action_config.key, document_action_config).html_safe
         else
           document_action_label(document_action_config.key, document_action_config).html_safe

--- a/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/trln_argon_helper_spec.rb
@@ -139,7 +139,7 @@ describe TrlnArgonHelper, type: :helper do
   describe '#add_icon_to_action_label' do
     let(:tool_with_label) do
       Blacklight::Configuration::ToolConfig.new(
-        icon: 'glyphicon-download-alt',
+        icon: 'fa fa-download',
         if: :render_ris_action?,
         modal: false,
         path: :ris_path
@@ -158,7 +158,7 @@ describe TrlnArgonHelper, type: :helper do
     context 'the configuration provides an icon' do
       it 'adds an icon to the document action label' do
         expect(helper.add_icon_to_action_label(tool_with_label)).to eq(
-          '<i class="glyphicon glyphicon-download-alt" aria-hidden="true"></i> <li>Action Label</li>'
+          '<i class="fa fa-download" aria-hidden="true"></i> <li>Action Label</li>'
         )
       end
     end


### PR DESCRIPTION
… TD-1180, TD-1181, TD-1191. Details as follows:

- Replace remaining glyphicon references with FontAwesome; fixes show tools & bookmark page icons TD-1181
- Fix the share bookmarks modal formatting TD-1180
- Replace defunct BS3 classes `control-label`, `help-block`, `form-horizontal`, `pull-left`, `pull-right` TD-1191

Advances the Bootstrap/Blacklight post-migration cleanup noted in #357 