### PR TITLE
Override bookmarks/_tools.html.erb

### DIFF
--- a/app/views/bookmarks/_tools.html.erb
+++ b/app/views/bookmarks/_tools.html.erb
@@ -1,3 +1,5 @@
+<!-- We override this file to remove the wrapping tag and wrapping classes for the buttons on the bookmarks page in the tools nav. Once this issue https://github.com/projectblacklight/blacklight/issues/2754 is addressed in BL, this file can be removed. -->
+
 <% if render_show_doc_actions_method_from_blacklight? %>
   <%= render(Blacklight::Document::ActionsComponent.new(document: nil, classes: "#{controller_name}Tools", link_classes: '', actions: document_actions(document_list, options: { document: nil }), options: { document_list: @response.documents }, url_opts: Blacklight::Parameters.sanitize(params.to_unsafe_h))) %>
 <% else %>

--- a/app/views/bookmarks/_tools.html.erb
+++ b/app/views/bookmarks/_tools.html.erb
@@ -1,0 +1,12 @@
+<% if render_show_doc_actions_method_from_blacklight? %>
+  <%= render(Blacklight::Document::ActionsComponent.new(document: nil, classes: "#{controller_name}Tools", link_classes: '', actions: document_actions(document_list, options: { document: nil }), options: { document_list: @response.documents }, url_opts: Blacklight::Parameters.sanitize(params.to_unsafe_h))) %>
+<% else %>
+  <% Deprecation.warn(self, '#render_show_doc_actions is deprecated; use ActionComponents instead') %>
+  <ul class="<%= controller_name %>Tools nav nav-pills">
+    <%= render_show_doc_actions document_list, document: nil, document_list: @response.documents, url_opts: Blacklight::Parameters.sanitize(params.to_unsafe_h) do |config, inner| %>
+      <li class="nav-item">
+        <%= inner %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>


### PR DESCRIPTION
We had to override the _tools.html.erb file in order to remove the wrapping tag and wrapping classes for the buttons on the bookmarks page in the tools nav. Once [this issue](https://github.com/trln/trln_argon/pull/370/files) is addressed in BL, this file can be removed.
![Screen Shot 2022-06-29 at 1 57 48 PM](https://user-images.githubusercontent.com/15024092/176506894-9328bf73-6c8d-44a8-b651-01cd16578c30.png)

