### PR TITLE
Fix accessibility violations on hierarchical location facet, adding "…

### DIFF
--- a/app/assets/javascripts/trln_argon/location_facet.js
+++ b/app/assets/javascripts/trln_argon/location_facet.js
@@ -26,7 +26,7 @@ Blacklight.onLoad(function() {
           facetLocationWrapper.find('ul.facet-hierarchy > .twiddle-open > ul > li').slice( parseInt(locationFacetLimit) ).hide();
 
           // add 'more' and 'less' button at end
-          facetLocationWrapper.find('ul.facet-hierarchy > .twiddle-open > ul').append( "<li class='location-more-toggle-wrapper'><a class='more_locations_link'>more <span class='sr-only'>Locations</span> »</a><a class='less_locations_link' style='display: none;'>less <span class='sr-only'>Locations</span> »</a></li>" );
+          facetLocationWrapper.find('ul.facet-hierarchy > .twiddle-open > ul').append( "<li role='treeitem' class='location-more-toggle-wrapper'><a class='more_locations_link'>more <span class='sr-only'>Locations</span> »</a><a class='less_locations_link' style='display: none;'>less <span class='sr-only'>Locations</span> »</a></li>" );
 
           // click 'more' to show all
           facetLocationWrapper.find('.more_locations_link').click(function() {
@@ -49,7 +49,7 @@ Blacklight.onLoad(function() {
 
     });
 
-    // general facet 'onclick' handler; needs some work AJC TODO 
+    // general facet 'onclick' handler; needs some work AJC TODO
     $('li.twiddle').on('click', function(t) {
       if ( t.target == this ) {
         $(this).toggleClass("twiddle-open");

--- a/lib/trln_argon/view_helpers/hierarchy_helper.rb
+++ b/lib/trln_argon/view_helpers/hierarchy_helper.rb
@@ -73,10 +73,12 @@ module TrlnArgon
           subul = subset.keys.collect do |subkey|
             render_facet_hierarchy_item(field_name, subset[subkey], subkey, sort)
           end.join('')
-          ul = "<ul>#{subul}</ul>".html_safe
+          # NOTE CHANGE: role="group" for accessibility
+          ul = %(<ul role="group">#{subul}</ul>).html_safe
         end
 
-        %(<li class="#{li_class}">#{li.html_safe}#{ul.html_safe}</li>).html_safe
+        # NOTE CHANGE: role="treeitem" for accessibility
+        %(<li role="treeitem" class="#{li_class}">#{li.html_safe}#{ul.html_safe}</li>).html_safe
       end
 
       def render_selected_qfacet_value(facet_solr_field, item)


### PR DESCRIPTION
…treeitem" and "group" aria roles. This matches what is done in more recent versions of the blacklight-hierarchy gem than we currently use. Fixes TD-1201 & TD-1202.