### PR TITLE
Adjust responsiveness for sidebar+main layout (snap to mobile mode at…

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -531,6 +531,23 @@ body.blacklight-trln-show {
     margin-top: 15px;
 }
 
+/* Workaround for BL core's hard-coded facet toggle breakpoint.       */
+/* This is a stopgap solution for Blacklight issue #2733 per TD-1172  */
+/* and should be replaced w/a BL-friendly approach once resolved.     */
+/* https://github.com/projectblacklight/blacklight/issues/2733        */
+
+.facets-toggleable-md {
+  @include media-breakpoint-up(md) {
+    .facets-collapse {
+      display: block !important;
+      width: 100%;
+    }
+
+    .navbar-toggler {
+      display: none;
+    }
+  }
+}
 
 
 /* =============== */

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -4,11 +4,11 @@ module LayoutHelper
   include Blacklight::LayoutHelperBehavior
 
   def main_content_classes
-    'col-lg-9 col-md-8 col-sm-7'
+    'col-lg-9 col-md-8'
   end
 
   def sidebar_classes
-    'col-lg-3 col-md-4 col-sm-5'
+    'page-sidebar col-lg-3 col-md-4'
   end
 
   def show_content_classes


### PR DESCRIPTION
… sm breakpoint instead of xs). Fix the sidebar toggler so it stops collapsing the facet nav section when it is still on the side. Closes TD-1170 & TD-1172.

### Medium Width (768px - 991px) Before:
<img width="800" alt="Screen Shot 2022-07-14 at 4 10 19 PM" src="https://user-images.githubusercontent.com/3933756/179078364-52ed5f56-5f6c-4108-87a4-a368a5e79139.png">

### Medium Width (768px - 991px) After:
<img width="798" alt="Screen Shot 2022-07-14 at 4 11 24 PM" src="https://user-images.githubusercontent.com/3933756/179078396-ab352a2a-1f3f-482a-9218-8990a11999e6.png">

### Small Width (576px - 767px) Before:
<img width="597" alt="Screen Shot 2022-07-14 at 4 12 23 PM" src="https://user-images.githubusercontent.com/3933756/179078462-037c904e-c565-4a16-99a5-cdb1ee15c035.png">

### Small Width (576px - 767px) After:
<img width="597" alt="Screen Shot 2022-07-14 at 4 12 37 PM" src="https://user-images.githubusercontent.com/3933756/179078512-28c04c55-b38a-4d31-b05a-90f8c5856d95.png">

