### PR TITLE
Rails 7/ BL 8 deprecation fix

### DIFF
--- a/lib/trln_argon/view_helpers/trln_argon_helper.rb
+++ b/lib/trln_argon/view_helpers/trln_argon_helper.rb
@@ -144,8 +144,9 @@ module TrlnArgon
         options[:value].join(', ')
       end
 
+      # @todo facets_from_request is removed in BL 8 https://github.com/projectblacklight/blacklight/commit/5b2def753dc3724bae5d3d4e70a69ed6453e185b
       def display_facet_hit_count(the_facet, the_value)
-        hits = facets_from_request.select { |f| f.name == the_facet }
+        hits = facets_from_request(facet_field_names, @response).select { |f| f.name == the_facet }
                                   .map(&:items)
                                   .first
                                   .select { |i| i.value == the_value }


### PR DESCRIPTION
Fixes:
 Blacklight Deprecation: Calling facets_from_request without passing the second argument (response) is deprecated and will be removed in Blacklight 8.0.0

https://trlnmain.atlassian.net/browse/TD-1313