### PR TITLE
Fix deprecation issue with deprecation proxy needing a deprecator object passed in

### DIFF
--- a/lib/trln_argon/controller_override/solr_caching.rb
+++ b/lib/trln_argon/controller_override/solr_caching.rb
@@ -21,7 +21,7 @@ module SolrCaching
     @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
       deprecated_document_list,
       'The @document_list instance variable is deprecated; '\
-      ' use @response.documents instead.')
+      ' use @response.documents instead.', ActiveSupport::Deprecation.new)
 
     respond_to do |format|
       format.html { store_preferred_view }


### PR DESCRIPTION
https://trlnmain.atlassian.net/browse/TD-1314

https://api.rubyonrails.org/v7.1.0/classes/ActiveSupport/Deprecation/DeprecatedObjectProxy.html