### PR TITLE
Bugfix: for location facets, only expand the current institution's to…

### DIFF
--- a/app/assets/javascripts/trln_argon/location_facet.js
+++ b/app/assets/javascripts/trln_argon/location_facet.js
@@ -10,14 +10,15 @@ Blacklight.onLoad(function() {
         var argonInstitution = $('#location-data').data('argon-institution');
         var locationFacetLimit = $('#location-data').data('location-facet-limit');
         var facetLocationWrapper = $('#facet-location_hierarchy_f');
+        var topLocationFacetItems = facetLocationWrapper.find('ul.facet-hierarchy > li');
 
-        // hide first two facets
-        facetLocationWrapper.find('.facet-select:contains("' + argonHSL + '")').closest('li').addClass("d-none");
-        facetLocationWrapper.find('.facet-select:contains("' + argonLAW + '")').closest('li').addClass("d-none");
+        // hide top-level HSL & Law facets
+        topLocationFacetItems.find('.facet-select:contains("' + argonHSL + '")').closest('li').addClass("d-none");
+        topLocationFacetItems.find('.facet-select:contains("' + argonLAW + '")').closest('li').addClass("d-none");
 
-        // open local institution and expand
-        facetLocationWrapper.find('.facet-select:contains("' + argonInstitution + '")').closest('li').addClass("twiddle-open");
-        facetLocationWrapper.find('.facet-select:contains("' + argonInstitution + '")').closest('li').children("ul.collapse").collapse('show');
+        // open top-level local institution and expand
+        topLocationFacetItems.find('.facet-select:contains("' + argonInstitution + '")').closest('li').addClass("twiddle-open");
+        topLocationFacetItems.find('.facet-select:contains("' + argonInstitution + '")').closest('li').children("ul.collapse").addClass("show");
 
         // if there are more than 10 results
         if ( facetLocationWrapper.find('ul.facet-hierarchy > .twiddle-open > ul > li').length > parseInt(locationFacetLimit) ) {


### PR DESCRIPTION
…p-level value, and don't animate the initial expansion.

- especially relevant for Duke, where nested locations including the string Duke were impacted
- preventing the intial animated transition expanding the facet is likely better for a11y