### PR TITLE
Create helper method for trln solr doc url

### DIFF
--- a/lib/trln_argon/trln_controller_behavior.rb
+++ b/lib/trln_argon/trln_controller_behavior.rb
@@ -15,6 +15,7 @@ module TrlnArgon
       helper_method :ris_url
       helper_method :show_solr_document_path
       helper_method :show_solr_document_url
+      helper_method :show_trln_solr_document_url
       helper_method :email_path
       helper_method :email_url
       helper_method :sms_path
@@ -52,6 +53,7 @@ module TrlnArgon
         return unless doc.respond_to?(:id)
         trln_solr_document_url(options.merge(id: doc.id))
       end
+      alias_method :show_trln_solr_document_url, :show_solr_document_url
 
       def filter_scope_name
         t('trln_argon.consortium.short_name')


### PR DESCRIPTION
I’m not sure what “magic” made this work in the past, but we now need an explicit method declaration. `show_solr_document_url` seems to do exactly what we want, so I created a `show_trln_solr_document_url` alias for it. The alternate links seem to show up correctly now in the page header.