### PR TITLE
Get basic Javascript working in BL8 using Sprockets. Closes TD-1355.

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -1,3 +1,5 @@
+<%# Customized copy of core BL base layout; see: -%>
+<%# https://github.com/projectblacklight/blacklight/blob/release-8.x/app/views/layouts/blacklight/base.html.erb -%>
 <!DOCTYPE html>
 <%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
   <head>
@@ -5,8 +7,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <!-- Internet Explorer use the highest version available -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <%# TRLN CUSTOMIZATION here:  -%>
     <%= render TrlnArgon::HighwireMetadataComponent.new(@document) %>
     <!-- data used by various JS routines -->
     <meta name="shared-application-data"
@@ -15,10 +16,25 @@
         data-google-books-logo-url="<%= asset_path('trln_argon/google_books_preview.png') %>">
 
     <title><%= render_page_title %></title>
+    <script>
+      document.querySelector('html').classList.remove('no-js');
+    </script>
+
     <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
     <%= favicon_link_tag %>
-    <%= stylesheet_link_tag "application", media: "all" %>
-    <%= javascript_include_tag "application" %>
+
+    <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload"  %>
+
+    <%# TRLN CUSTOMIZATION here: -%>
+    <%# We remove BL8's code here that defaults to Importmap or Propshaft and -%>
+    <%# instead just use the traditional Sprockets-compiled application.js    -%>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+
+    <%# TODO: This module is added by default in BL8. Investigate whether we  -%>
+    <%# need it, given TRLN's specific typeahead/autocomplete setup. -%>
+    <script type="module">
+      import githubAutoCompleteElement from 'https://cdn.skypack.dev/@github/auto-complete-element';
+    </script>
 
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
@@ -27,17 +43,18 @@
     <%= render blacklight_config.skip_link_component.new do %>
       <%= content_for(:skip_links) %>
     <% end %>
+
     <%= render partial: 'shared/header_navbar' %>
 
-  <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
-    <%= content_for(:container_header) %>
+    <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
+      <%= content_for(:container_header) %>
 
-    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+      <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
 
-    <div class="row">
-      <%= content_for?(:content) ? yield(:content) : yield %>
-    </div>
-  </main>
+      <div class="row">
+        <%= content_for?(:content) ? yield(:content) : yield %>
+      </div>
+    </main>
 
     <%= render partial: 'shared/footer' %>
     <%= render partial: 'shared/modal' %>

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -21,12 +21,27 @@ class TestAppGenerator < Rails::Generators::Base
   end
 
   def run_blacklight_generator
-    say_status('warning', 'GENERATING BL', :yellow)
+    say_status('info', '================================', :magenta)
+    say_status('info', 'Generating Blacklight w/o assets', :magenta)
+    say_status('info', '================================', :magenta)
 
-    generate 'blacklight:install', '--devise', '--skip-solr'
+    # Skip the default BL assets generator via --skip-assets:
+    generate 'blacklight:install', '--devise', '--skip-solr', '--skip-assets'
+
+    # We need to explicitly specify BL8's Sprockets assets generator, else
+    # BL will assume we want to use Propshaft or Importmap. See:
+    # https://github.com/projectblacklight/blacklight/blob/release-8.x/lib/generators/blacklight/assets_generator.rb
+    # https://github.com/projectblacklight/blacklight/blob/release-8.x/lib/generators/blacklight/assets/sprockets_generator.rb
+    say_status('info', '========================================', :magenta)
+    say_status('info', 'Generating Blacklight assets w/Sprockets', :magenta)
+    say_status('info', '========================================', :magenta)
+    generate 'blacklight:assets:sprockets'
   end
 
   def install_engine
+    say_status('info', '============================', :magenta)
+    say_status('info', 'Generating TRLN Argon engine', :magenta)
+    say_status('info', '============================', :magenta)
     generate 'trln_argon:install'
   end
 end

--- a/trln_argon.gemspec
+++ b/trln_argon.gemspec
@@ -35,7 +35,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'citeproc-ruby', '~> 1.1'
   s.add_dependency 'csl-styles', '~> 1.0'
   s.add_dependency 'bibtex-ruby', '>= 4.4.6', '< 7'
-  
+  s.add_dependency 'jquery-rails', '~> 4.6'
+
   s.add_development_dependency 'rspec-rails', '~> 6'
   s.add_development_dependency 'capybara', '~> 3.29'
   s.add_development_dependency 'pry', '~> 0.14'


### PR DESCRIPTION
- Update the customized copy of BL core base layout; omit its references to Importmap & Propshaft
- Run the BL generator with --skip-assets to bypass the Importmap setup
- Run the BL assets generator for Sprockets (blacklight:assets:sprockets)
- Add & require jQuery as a dependency (no longer included via Bootstrap 5)
- Add more info output to steps in the generator to clarify what is happening