### PR TITLE
Fix various build issues (esp JS related), improving support for Ruby…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=3.0.0
+ARG RUBY_VERSION=3.1.6
 FROM ruby:${RUBY_VERSION} AS app_bootstrap
 
 RUN apt-get update && apt-get install -y nodejs vim less

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ FROM app_bootstrap AS runnable
 COPY --from=builder /gems /gems
 COPY ./bundler_config.rb .
 
+# This line is a workaround that seems to be needed when using
+# using ruby:3.1.x Docker images, to prevent this error:
+# `check_for_activated_spec!': You have already activated error_highlight 0.3.0, but your Gemfile requires error_highlight 0.6.0 ...
+RUN gem update error_highlight
+
 RUN $(./bundler_config.rb path /gems)
 
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -28,10 +28,15 @@ if File.exist?(file)
 else
   Bundler.ui.warn "[EngineCart] Unable to find test application dependencies in #{file}, using placeholder dependencies"
 
+  # TRLN CUSTOMIZATION:
+  # We'll use the Rails --skip-javascript flag so when generated we
+  # won't get the default JS files in app/javascript. We are sticking
+  # with Sprockets for now; our JS is in app/assets/javascripts.
+  ENV['ENGINE_CART_RAILS_OPTIONS'] = '--skip-javascript'
   if ENV['RAILS_VERSION']
     if ENV['RAILS_VERSION'] == 'edge'
       gem 'rails', github: 'rails/rails'
-      ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
+      ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks --skip-javascript'
     else
       gem 'rails', ENV['RAILS_VERSION']
     end

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ gem 'trln_argon', git: 'https://github.com/trln/trln_argon'
 3. Run the following:
 
         $ bundle install
-        $ bundle exec rails generate blacklight:install --devise --skip-solr
+        $ bundle exec rails generate blacklight:install --devise --skip-solr --skip-javascript
         $ bundle exec rails generate trln_argon:install
         $ bundle exec rake db:migrate
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,8 +14,8 @@ if [ -e "${PIDFILE}" ]; then
     rm "$PIDFILE"
 fi
 
-case $1 in 
-    clean) 
+case $1 in
+    clean)
         rm -rf .internal_test_app
         echo "Test application removed. You can start this container again to get a freshly generated application"
         ;;
@@ -42,7 +42,7 @@ case $1 in
         ;;
     shell)
         exec /bin/bash;;
-    *) 
+    *)
         exec "$@"
         ;;
 esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ check_bundle() {
 
 cd /app || exit
 
-export BOOTSTRAP_VERSION=${BOOTSTRAP_VERSION:-'~>5.3'}
+export BOOTSTRAP_VERSION="${BOOTSTRAP_VERSION:-~>5.3}"
 
 PIDFILE=.internal_test_app/tmp/pids/server.pid
 

--- a/lib/generators/trln_argon/install_generator.rb
+++ b/lib/generators/trln_argon/install_generator.rb
@@ -64,6 +64,7 @@ module TrlnArgon
       say_status('info', '============================', :magenta)
       prepend_to_file 'app/assets/config/manifest.js', "//= link trln_argon_manifest.js\n"
       prepend_to_file 'app/assets/config/manifest.js', "//= link blacklight/manifest.js\n"
+      append_to_file 'app/assets/config/manifest.js', "//= link application.js\n"
     end
 
     def install_stylesheet

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -10,12 +10,13 @@ class TestAppGenerator < Rails::Generators::Base
   def add_gems
     gem 'blacklight', '~> 8.0'
 
-    if RUBY_VERSION < '3.0'
+    if RUBY_VERSION < '3.1'
+      say_status('info', 'Adding Hack for Ruby < 3.1', :magenta)
       # Hack for https://github.com/cbeer/engine_cart/issues/125
       gsub_file 'Gemfile', /^gem ["']sqlite3["'].*$/, 'gem "sqlite3", "< 1.7"'
     end
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       run 'bundle install'
     end
   end
@@ -36,6 +37,10 @@ class TestAppGenerator < Rails::Generators::Base
     say_status('info', 'Generating Blacklight assets w/Sprockets', :magenta)
     say_status('info', '========================================', :magenta)
     generate 'blacklight:assets:sprockets'
+
+    Bundler.with_unbundled_env do
+      run 'bundle install'
+    end
   end
 
   def install_engine

--- a/trln_argon.gemspec
+++ b/trln_argon.gemspec
@@ -49,4 +49,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'better_errors', '~> 2.9.1'
   s.add_development_dependency 'binding_of_caller', '~> 1.0'
   s.add_development_dependency 'rake', '~> 13'
+
+  # Conditionally constrain sqlite3 to version that still works with Ruby 3.0
+  # TODO: remove when we are all using Ruby 3.1+.
+  if Gem::Requirement.new('< 3.1').satisfied_by?(Gem::Version.new(RUBY_VERSION))
+    s.add_dependency 'sqlite3', '< 1.7'
+  end
 end


### PR DESCRIPTION
… 3.0-3.3 containerized or otherwise. Fixes TD-1358.

- Adds --skip-javascript flag for Rails generator in both containerized & noncontainerized environments
- This prevents generation of default Rails Hotwire app/javascript files
- Generates link to application.js in the app/assets/config/manifest.js (above ensures no conflict with app/javascript/application.js)
- Replaces deprecated Bundler.with_clean_env with Bundler.with_unbundled_env
- Adds SQLite3 version workarounds for Ruby 3.0.x (generator log still complains, but it seems to work)