### PR TITLE
Improve BetterErrors support, especially when using Docker. Closes TD…

### DIFF
--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -48,5 +48,9 @@ class TestAppGenerator < Rails::Generators::Base
     say_status('info', 'Generating TRLN Argon engine', :magenta)
     say_status('info', '============================', :magenta)
     generate 'trln_argon:install'
+
+    Bundler.with_unbundled_env do
+      run 'bundle install'
+    end
   end
 end

--- a/trln_argon.gemspec
+++ b/trln_argon.gemspec
@@ -46,8 +46,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr', '~> 5.0'
   s.add_development_dependency 'engine_cart', '~> 2.2'
   s.add_development_dependency 'listen'
-  s.add_development_dependency 'better_errors', '~> 2.9.1'
-  s.add_development_dependency 'binding_of_caller', '~> 1.0'
   s.add_development_dependency 'rake', '~> 13'
 
   # Conditionally constrain sqlite3 to version that still works with Ruby 3.0


### PR DESCRIPTION
…-1132.

- Removes better_errors & binding_of_caller from the gemspec (per TD-1132)
- Ensure that BetterErrors only gets loaded in development environments for .internal_test_app
- Add RFC1918 private subnets to IPs permitted to show BetterErrors; esp. appears to be needed for Docker on Mac
- Note that loopback addresses IPv4 127.x.x.x & IPv6 ::1 are permitted by default