### PR TITLE
Replace sass-rails & sassc-rails with dartsass-sprockets, and accommo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /app
 
 EXPOSE 3000
 
-ENV ENGINE_CART_RAILS_OPTIONS="--skip-webpack-install --skip-javascript"
+ENV ENGINE_CART_RAILS_OPTIONS="--skip-webpack-install --skip-javascript --skip-bundle"
 
 ENV BOOTSTRAP_VERSION="~> 5.3"
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gemspec
 # engine_cart stanza: 2.5.0
 # the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
 file = File.expand_path('Gemfile', ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path('.internal_test_app', File.dirname(__FILE__)))
+
 if File.exist?(file)
   begin
     eval_gemfile file
@@ -32,7 +33,11 @@ else
   # We'll use the Rails --skip-javascript flag so when generated we
   # won't get the default JS files in app/javascript. We are sticking
   # with Sprockets for now; our JS is in app/assets/javascripts.
-  ENV['ENGINE_CART_RAILS_OPTIONS'] = '--skip-javascript'
+  # We also run --skip-bundle to avoid running `bundle install` upon the
+  # initial creation of the Rails app. We'll run it later in our generator
+  # steps after customizing the Gemfile.
+  ENV['ENGINE_CART_RAILS_OPTIONS'] = '--skip-javascript --skip-bundle'
+
   if ENV['RAILS_VERSION']
     if ENV['RAILS_VERSION'] == 'edge'
       gem 'rails', github: 'rails/rails'
@@ -40,8 +45,6 @@ else
     else
       gem 'rails', ENV['RAILS_VERSION']
     end
-
-    gem 'sass-rails', '>= 6'
   end
 end
 # END ENGINE_CART BLOCK

--- a/app/assets/stylesheets/trln_argon/trln_argon_dependencies.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_dependencies.scss
@@ -2,6 +2,8 @@
 
 @import 'bootstrap';
 
+@import 'blacklight/blacklight';
+
 @import 'blacklight_advanced_search';
 
 @import 'blacklight/hierarchy/hierarchy';

--- a/lib/generators/trln_argon/install_generator.rb
+++ b/lib/generators/trln_argon/install_generator.rb
@@ -177,6 +177,17 @@ module TrlnArgon
       end
     end
 
+    def setup_application_scss
+      say_status('info', '===========================', :magenta)
+      say_status('info', 'Setting up application.scss', :magenta)
+      say_status('info', '===========================', :magenta)
+      insert_into_file 'app/assets/stylesheets/application.scss' do
+        <<~CONTENT
+          @import 'trln_argon';
+        CONTENT
+      end
+    end
+
     def remove_turbolinks # via http://codkal.com/rails-how-to-remove-turbolinks/
       gsub_file('Gemfile', "gem 'turbolinks',", '')
       if File.exist?('app/assets/javascripts/application.js')

--- a/trln_argon.gemspec
+++ b/trln_argon.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rsolr', '>= 1.0', '< 3'
   s.add_dependency 'addressable', '~> 2.5'
   s.add_dependency 'sprockets', '~> 4.0'
-  s.add_dependency 'trln-chosen-rails', '~> 1.20'
+  s.add_dependency 'trln-chosen-rails', '1.30.0.pre.beta'
   s.add_dependency 'citeproc-ruby', '~> 1.1'
   s.add_dependency 'csl-styles', '~> 1.0'
   s.add_dependency 'bibtex-ruby', '>= 4.4.6', '< 7'
@@ -48,9 +48,27 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'listen'
   s.add_development_dependency 'rake', '~> 13'
 
-  # Conditionally constrain sqlite3 to version that still works with Ruby 3.0
-  # TODO: remove when we are all using Ruby 3.1+.
+  # Ruby 3.x compatibility: some gems and their dependencies need to be
+  # pinned to specific versions to work with different Ruby 3.x versions
+
+  # Ruby 3.0
+  # =================
   if Gem::Requirement.new('< 3.1').satisfied_by?(Gem::Version.new(RUBY_VERSION))
     s.add_dependency 'sqlite3', '< 1.7'
+
+    s.add_dependency 'dartsass-sprockets', '< 3.1.0'
+    s.add_dependency 'sass-embedded', '<= 1.69.5'
+    s.add_dependency 'dartsass-ruby', '>= 3.0.2'
+
+  # Ruby 3.1
+  # =================
+  elsif Gem::Requirement.new('< 3.2').satisfied_by?(Gem::Version.new(RUBY_VERSION))
+    s.add_dependency 'dartsass-sprockets'
+    s.add_dependency 'sass-embedded', '<= 1.70'
+
+  # Ruby 3.2+
+  # =================
+  else
+    s.add_dependency 'dartsass-sprockets'
   end
 end


### PR DESCRIPTION
…date Ruby 3.0. Closes TD-1345 & TD-1360.

- Remove the sassc-rails gem that BL adds via its sprockets asset generator
- Run the rails generator with --skip-bundle; avoids installing gems we won't use
- Update trln-chosen-rails to a version that does not depend on sassc-rails
- Conditionally constrain dartsass-sprockets and its dependencies for Ruby 3.0 & 3.1 support