### PR TITLE
TD-1371 hide toggle icons

### DIFF
--- a/app/components/trln_argon/search/sidebar_component.html.erb
+++ b/app/components/trln_argon/search/sidebar_component.html.erb
@@ -1,7 +1,22 @@
 <% # TRLN override of BL8 sidebar component %>
-<%= render 'catalog/local_filter',
-           local_button_id: 'toggle-local-btn-top',
-           trln_button_id: 'toggle-trln-btn-top' %>
+<% inst = TrlnArgon::Engine.configuration.local_institution_code %>
+<% instname = TrlnArgon::LookupManager.instance.map("#{inst}.facet.#{inst}") %>
+
+<div id="location-data"
+     data-argon-institution="<%= instname %>"
+     data-argon-hsl="<%= TrlnArgon::LookupManager.instance.map('hsl.facet.hsl') %>"
+     data-argon-law="<%= TrlnArgon::LookupManager.instance.map('law.facet.law') %>"
+     data-location-facet-limit="<%= TrlnArgon::Engine.configuration.number_of_location_facets %>">
+</div>
+
+<div id="trln-toggle" class="sidenav facets top-panel-heading">
+  <div id="viewAllResults" class="clearfix" role="navigation" aria-label="Searching (context)">
+    <%= render 'catalog/local_filter',
+              filter_label_id: 'localFilterLabelFacets',
+              local_button_id: 'toggle-local-btn-top',
+              trln_button_id: 'toggle-trln-btn-top' %>
+  </div>
+</div>
 
 <search>
   <% facet_group_names.each do |groupname| %>

--- a/app/views/catalog/_local_filter.html.erb
+++ b/app/views/catalog/_local_filter.html.erb
@@ -1,45 +1,31 @@
-<% inst = TrlnArgon::Engine.configuration.local_institution_code %>
-<% instname = TrlnArgon::LookupManager.instance.map("#{inst}.facet.#{inst}") %>
+<h2 class="local-filter-heading" id="<%= filter_label_id %>">
+  <%= t("trln_argon.local_filter.showing_results") %>
+</h2>
 
-<div id="location-data"
-     data-argon-institution="<%= instname %>"
-     data-argon-hsl="<%= TrlnArgon::LookupManager.instance.map('hsl.facet.hsl') %>"
-     data-argon-law="<%= TrlnArgon::LookupManager.instance.map('law.facet.law') %>"
-     data-location-facet-limit="<%= TrlnArgon::Engine.configuration.number_of_location_facets %>">
+<% query_state = query_state_from_search_state(search_state) %>
+<% query_state.delete('page') %>
+<% query_state.fetch('f', {}).delete(TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.to_s) %>
+
+<div class="toggle toggle-local">
+  <%= button_tag(type: "button", id: local_button_id, class: "btn btn-md #{local_search_button_class}",
+                title: "#{t('trln_argon.local_filter.search_verb')} #{t('trln_argon.local_filter.searching_local', local_institution_name: institution_long_name)}",
+                onclick: "window.location='#{search_catalog_path(query_state)}'") do %>
+    <span class="visually-hidden">icon</span><span class="icon-wrapper"></span>
+  <% end %>
+
+  <%= label_tag(local_button_id, t('trln_argon.local_filter.searching_local', local_institution_name: institution_long_name),
+                class: "#{local_search_button_label_class}",
+                data: { count_only_path: trln_argon.catalog_count_only_path(query_state) }) %>
 </div>
 
-<div id="trln-toggle" class="sidenav facets top-panel-heading">
-  <div id="viewAllResults" class="clearfix" role="navigation" aria-label="Searching (context)">
-    <h2 class="local-filter-heading" id="localFilterLabelFacets">
-      <%= t("trln_argon.local_filter.showing_results") %>
-    </h2>
+<div class="toggle toggle-trln">
+  <%= button_tag(type: "button", id: trln_button_id, class: "btn btn-md #{trln_search_button_class}",
+                title: "#{t('trln_argon.local_filter.search_verb')} #{t('trln_argon.local_filter.searching_trln')}",
+                onclick: "window.location='#{search_trln_path(query_state)}'") do %>
+    <span class="visually-hidden">icon</span><span class="icon-wrapper"></span>
+  <% end %>
 
-    <% query_state = query_state_from_search_state(search_state) %>
-    <% query_state.delete('page') %>
-    <% query_state.fetch('f', {}).delete(TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.to_s) %>
-
-    <div class="toggle toggle-local">
-      <%= button_tag(type: "button", id: local_button_id, class: "btn btn-md #{local_search_button_class}",
-                    title: "#{t('trln_argon.local_filter.search_verb')} #{t('trln_argon.local_filter.searching_local', local_institution_name: institution_long_name)}",
-                    onclick: "window.location='#{search_catalog_path(query_state)}'") do %>
-        <span class="visually-hidden">icon</span><span class="icon-wrapper"></span>
-      <% end %>
-
-      <%= label_tag(local_button_id, t('trln_argon.local_filter.searching_local', local_institution_name: institution_long_name),
-                    class: "#{local_search_button_label_class}",
-                    data: { count_only_path: trln_argon.catalog_count_only_path(query_state) }) %>
-    </div>
-
-    <div class="toggle toggle-trln">
-      <%= button_tag(type: "button", id: trln_button_id, class: "btn btn-md #{trln_search_button_class}",
-                    title: "#{t('trln_argon.local_filter.search_verb')} #{t('trln_argon.local_filter.searching_trln')}",
-                    onclick: "window.location='#{search_trln_path(query_state)}'") do %>
-        <span class="visually-hidden">icon</span><span class="icon-wrapper"></span>
-      <% end %>
-
-      <%= label_tag(trln_button_id, t('trln_argon.local_filter.searching_trln'),
-                    class: "#{trln_search_button_label_class}",
-                    data: { count_only_path: trln_argon.trln_count_only_path(query_state) }) %>
-    </div>
-  </div>
+<%= label_tag(trln_button_id, t('trln_argon.local_filter.searching_trln'),
+              class: "#{trln_search_button_label_class}",
+              data: { count_only_path: trln_argon.trln_count_only_path(query_state) }) %>
 </div>

--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -3,7 +3,9 @@
   <div class="col-md-12">
     <%= render Blacklight::Response::PaginationComponent.new(response: @response, html: {}, outer_window: 0) %>
       <div id="viewAllResultsEnd" class="clearfix">
-        <%= render :partial => "local_filter", locals: { local_filter_id: 'localFilterLabelFooter', local_button_id: 'toggle-local-btn-bottom', trln_button_id: 'toggle-trln-btn-bottom' } %>
+        <%= render :partial => "local_filter", locals: { filter_label_id: 'localFilterLabelFooter',
+                                                         local_button_id: 'toggle-local-btn-bottom',
+                                                         trln_button_id: 'toggle-trln-btn-bottom' } %>
       </div>
   </div>
  </div>

--- a/app/views/catalog/_view_all_filter.html.erb
+++ b/app/views/catalog/_view_all_filter.html.erb
@@ -1,5 +1,0 @@
-<% unless @response.empty? %>
-<div id="viewAllResults" class="clearfix">
-  <%= render :partial => "local_filter", locals: { local_filter_id: 'localFilterLabelFacets' } %>
-</div>
-<% end %>


### PR DESCRIPTION
- Cleans up the templates involved in rendering the trln/local toggle in the sidebar (all pages) and footer/pagination area (only on search results pages).
- Institution icons now only appear in the sidebar (not the footer), and the on-click behavior works correctly
- Deprecates _view_all_filter.html.erb partial (does not override anything in BL8, is not rendered anywhere in TRLN Argon)

<img width="342" alt="Screenshot 2024-11-05 at 3 24 17 PM" src="https://github.com/user-attachments/assets/a5959425-3c93-4833-8abc-c91b8b3b923d">
<img width="672" alt="Screenshot 2024-11-05 at 3 23 55 PM" src="https://github.com/user-attachments/assets/449d4af0-e376-4997-a263-64263b8f79a6">
