### PR TITLE
re-scope JS function isInViewport

### DIFF
--- a/app/assets/javascripts/trln_argon/expand_contract.js
+++ b/app/assets/javascripts/trln_argon/expand_contract.js
@@ -1,13 +1,16 @@
-// test if an element is in the viewport
-$.fn.isInViewport = function() {
-  var elementTop = $(this).offset().top;
-  var elementBottom = elementTop + $(this).outerHeight();
-  var viewportTop = $(window).scrollTop();
-  var viewportBottom = viewportTop + $(window).height();
-  return elementBottom > viewportTop && elementTop < viewportBottom;
-};
-
 Blacklight.onLoad(function() {
+
+  /**
+    * Tests whether an element is vertically
+    * contained within the current viewport
+    **/
+  $.fn.isInViewport = function() {
+    var elementTop = $(this).offset().top;
+    var elementBottom = elementTop + $(this).outerHeight();
+    var viewportTop = $(window).scrollTop();
+    var viewportBottom = viewportTop + $(window).height();
+    return elementBottom > viewportTop && elementTop < viewportBottom;
+  };
 
   $("#documents .hider, #holdings .hider").click(function(evt) {
     evt.preventDefault();


### PR DESCRIPTION
previously the global jQuery custom function was defined outside of the scope of the `Blacklight.load` handler, and may have attempted to access the `$` variable before it was properly set up as an alias for `jQuery`

(this change should be merged before switching over to `trln-chosen-rails ` v1.30.0