### PR TITLE
move def of isInViewport function to safer scope

### DIFF
--- a/app/assets/javascripts/trln_argon/expand_contract.js
+++ b/app/assets/javascripts/trln_argon/expand_contract.js
@@ -1,13 +1,16 @@
-// test if an element is in the viewport
-$.fn.isInViewport = function() {
-  var elementTop = $(this).offset().top;
-  var elementBottom = elementTop + $(this).outerHeight();
-  var viewportTop = $(window).scrollTop();
-  var viewportBottom = viewportTop + $(window).height();
-  return elementBottom > viewportTop && elementTop < viewportBottom;
-};
-
 Blacklight.onLoad(function() {
+
+  /**
+    * Tests whether an element is vertically
+    * contained within the current viewport
+    **/
+  $.fn.isInViewport = function() {
+    var elementTop = $(this).offset().top;
+    var elementBottom = elementTop + $(this).outerHeight();
+    var viewportTop = $(window).scrollTop();
+    var viewportBottom = viewportTop + $(window).height();
+    return elementBottom > viewportTop && elementTop < viewportBottom;
+  };
 
   $("#documents .hider, #holdings .hider").click(function(evt) {
     evt.preventDefault();


### PR DESCRIPTION
Function definition was outside `Blacklight.load` context meaning aliasing of `$` to `jQuery` might not have been done yet.