### PR TITLE
TD-1383 (In Advanced Search, the publication year facet text fields should be shorter)

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -1624,6 +1624,23 @@ h2.local-filter-heading {
   }
 }
 
+/* Custom styles for range input boxes */
+.range_limit .form-control.range_begin {
+  width: 100px;
+  display: inline-block;
+  margin-right: 8px;
+}
+
+.range_limit .form-control.range_end {
+  width: 100px;
+  display: inline-block;
+  margin-left: 8px;
+}
+
+.range_limit {
+  display: flex;
+  align-items: center;
+}
 
 
 /* =============== */


### PR DESCRIPTION
-adds CSS to make Advanced Search Publication Year input fields shorter and fit onto one line
-resolves [TD-1383](https://trlnmain.atlassian.net/browse/TD-1383)

<img width="493" alt="Screenshot 2024-11-15 at 12 44 14 PM" src="https://github.com/user-attachments/assets/b0632e18-3fd6-4cd7-bdd4-22f898ce978d">
