### PR TITLE
Fix DartSass-Sprockets compilation errors in production ENV.

### DIFF
--- a/app/assets/stylesheets/blacklight/_controls.scss
+++ b/app/assets/stylesheets/blacklight/_controls.scss
@@ -1,0 +1,63 @@
+/* We need to backport this BL commit to BL8 else DartSass-Sprockets will fail */
+/* to compile in production mode. */
+/* https://github.com/projectblacklight/blacklight/commit/d7416f4179fd314cc1c827da36ad57a1aa543e52 */
+
+/* Bootstrap's breakpoint-max(xs) when xs = 0 evaluates to null, and DartSass complains   */
+/* See: https://github.com/twbs/bootstrap/blob/main/scss/mixins/_breakpoints.scss#L34-L46 */
+
+.search-widgets {
+  display: flex;
+
+  > * {
+    @extend .mx-1;
+  }
+}
+
+.sort-pagination,
+.pagination-search-widgets {
+  border-bottom: $pagination-border-width solid $pagination-border-color;
+  margin-bottom: 1em;
+  padding-bottom: 1em;
+}
+
+.pagination-search-widgets {
+  padding-top: 1px;
+  padding-bottom: $spacer;
+}
+
+.sort-pagination .dropdown-toggle {
+  cursor: pointer;
+}
+
+.no-js {
+  .btn-group:focus-within {
+    .dropdown-menu {
+      @extend .show;
+    }
+  }
+}
+
+.view-type {
+  display: inline-block;
+
+  .caption {
+    @extend .sr-only !optional;
+    @extend .visually-hidden !optional;
+  }
+}
+
+.search-input-group {
+  width: 80%;
+}
+
+/* This block is what breaks DartSass-Sprockets compilation:
+@media (max-width: breakpoint-max(xs)) {
+  .search-input-group {
+    width: auto;
+  }
+}
+*/
+
+.modal_form {
+  margin-bottom: 0;
+}

--- a/app/assets/stylesheets/trln_argon/trln_argon_dependencies.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_dependencies.scss
@@ -2,7 +2,33 @@
 
 @import 'bootstrap';
 
-@import 'blacklight/blacklight';
+// Commented out the default blacklight @import so we have more
+// granular control over overriding individual @imports with
+// local files. We will be able to revert once the breakpoint-max(xs)
+// bugfix is backported to BL8 (see blacklight/_controls.scss).
+// See: https://github.com/projectblacklight/blacklight/blob/release-8.x/app/assets/stylesheets/blacklight/_blacklight_base.scss
+
+// @import 'blacklight/blacklight';
+// --------------------------------
+@import "blacklight/mixins";
+@import 'blacklight/blacklight_defaults';
+@import "blacklight/bootstrap_overrides";
+@import "blacklight/layout";
+@import "blacklight/header";
+@import "blacklight/constraints";
+@import "blacklight/controls"; // <-- temporary local override
+@import "blacklight/search_form";
+@import "blacklight/search_results";
+@import "blacklight/pagination";
+@import "blacklight/group";
+@import "blacklight/bookmark";
+@import "blacklight/balanced_list";
+@import "blacklight/facets";
+@import "blacklight/search_history";
+@import "blacklight/modal";
+@import "blacklight/icons";
+@import "blacklight/autocomplete";
+// --------------------------------
 
 @import 'blacklight_advanced_search';
 
@@ -10,4 +36,6 @@
 
 @import 'font-awesome';
 
-@import 'chosen';
+// Must specify .css extension to disambiguate from chosen.scss
+// https://github.com/trln/chosen-rails/blob/remove-sassc/vendor/assets/stylesheets/chosen.css
+@import 'chosen.css';

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -33,6 +33,15 @@ class TestAppGenerator < Rails::Generators::Base
     generate 'blacklight:assets:sprockets'
   end
 
+  def remove_blacklight_scss
+    # We don't want the BL-generated blacklight.scss file since we are already using
+    # trln_argon_dependencies.scss to @import bootstrap & blacklight styles.
+    say_status('info', '=============================', :magenta)
+    say_status('info', 'Removing Blacklight SCSS file', :magenta)
+    say_status('info', '=============================', :magenta)
+    remove_file 'app/assets/stylesheets/blacklight.scss'
+  end
+
   # The sassc-rails gem is added by the BL assets generator but we don't want it.
   # We'll use dartsass-sprockets instead.
   # https://github.com/projectblacklight/blacklight/blob/release-8.x/lib/generators/blacklight/assets/sprockets_generator.rb#L33


### PR DESCRIPTION
- Adds a temporary shim to patch a BL core bug where breakpoint-max(xs) was used
- Removes the default blacklight.scss file that the BL assets generator creates, since... we import those files already in trln_argon_dependencies.scss; duplicates cause problems
- Specifies the pre-compiled chosen.css for import from trln-chosen-rails, so chosen.scss is not used