### PR TITLE
Remove search  history controller override

### DIFF
--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class SearchHistoryController < ApplicationController
-  include Blacklight::SearchHistory
-end


### PR DESCRIPTION
The override of `search_history_controller.rb` depended on removed things from the range limit gem; in development mode this caused no issue as the class was never loaded, but in production where things are aggressively loaded, the application would fail to start.

moral: make sure the application runs in production mode before merging changes =)