### PR TITLE
Replace deprecated lighten() & darken() with BS5 tint-color() & shade…

### DIFF
--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -315,12 +315,10 @@ body {
 
   .link-type-fulltext,
   .link-type-findingaid {
-    /*border-radius: 4px;*/
     color: #fff;
     display: inline-block;
-    background: darken($primary-color, 20%);
+    background: shade-color($primary-color, 20%);
     padding: .5em .75em .5em 2em;
-    /*border: 1px solid darken($primary-color, 10%)*/
     line-height: 1.2;
     text-align: left;
     text-decoration: none;
@@ -330,7 +328,7 @@ body {
   .link-type-fulltext:focus,
   .link-type-findingaid:hover,
   .link-type-findingaid:focus {
-    background: darken($primary-color, 10%);
+    background: shade-color($primary-color, 10%);
     text-decoration: none;
   }
 
@@ -1240,7 +1238,7 @@ h5 {
 
   .btn-info {
     background-color: $primary-color;
-    border-color: darken($primary-color, 10%);
+    border-color: shade-color($primary-color, 10%);
   }
 
 
@@ -1515,11 +1513,11 @@ div.marc-record {
 
 .progressive-link-hover {
   text-decoration: underline;
-  background-color: lighten($primary-link-color, 50%);
+  background-color: tint-color($primary-link-color, 50%);
 }
 
 .progressive-link-hover:hover {
-  color: darken($primary-link-color, 40%);
+  color: shade-color($primary-link-color, 40%);
 }
 
 #included-works .progressive-link-wrapper,
@@ -1593,7 +1591,7 @@ div.marc-record {
 
   &:hover {
     text-decoration: none;
-    background: lighten($primary-link-color, 10%);
+    background: tint-color($primary-link-color, 10%);
   }
 
 }

--- a/app/assets/stylesheets/trln_argon/trln_argon_variables_defaults.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_variables_defaults.scss
@@ -18,8 +18,8 @@ $primary-color: #4b7ca9 !default; // this is 'UNC Blue'
 $secondary-color: #2e4972 !default; // this should be a darker hue than primary
 $tertiary-color: #5099b4 !default; // this should be a lighter hue than primary
 
-$primary-link-color: darken( $primary-color, 5% ) !default;
-$secondary-link-color: darken( $primary-color, 15% ) !default;
+$primary-link-color: shade-color($primary-color, 5%) !default;
+$secondary-link-color: shade-color($primary-color, 15%) !default;
 
 $facet-grey: #f5f5f5 !default; // use in facets and results lists
 

--- a/lib/generators/trln_argon/templates/trln_argon_variables.scss
+++ b/lib/generators/trln_argon/templates/trln_argon_variables.scss
@@ -1,3 +1,5 @@
+@import "bootstrap/functions"; // for shade-color & tint-color
+
 /* IMPORTANT: Make changes to variable settings in this file
               to override default settings from Argon.
               In the Argon gem see app/assets/stylesheets/trln_argon_variables_defaults.scss
@@ -17,17 +19,16 @@ $institution-icon-inverted: 'branding/unc_icon_inverted.png';
 // maintain adequate contrast ratio (> 4.5:1 on white background) for AxS purposes !
 
 $primary-color: #4b7ca9; // this is 'UNC Blue'
-$secondary-color: darken( $primary-color, 20% ); // this should be a darker hue than primary
-$tertiary-color: lighten( $primary-color, 20% ); // this should be a lighter hue than primary
+$secondary-color: shade-color($primary-color, 20%); // this should be a darker hue than primary
+$tertiary-color: tint-color($primary-color, 20%); // this should be a lighter hue than primary
 
-$primary-link-color: darken( $primary-color, 5% );
-$secondary-link-color: darken( $primary-color, 15% );
+$primary-link-color: shade-color($primary-color, 5%);
+$secondary-link-color: shade-color($primary-color, 15%);
 
 $facet-grey: #f5f5f5; // use in facets and results lists
 
 $available-color: #157d1e; // default is green
 $not-available-color: #b11f1f; // default is red
 $alt-available-color: #7d6816; // default is brown
-
 
 $trln-green: #209d8b; // this is 'TRLN Green'


### PR DESCRIPTION
…-color(). Advances TD-1379.

- Cuts down on excessive DartSass-Sprockets deprecation warnings, which cannot yet be turned off
- Note @import "bootstrap/functions" needed at top of variables file so those are available