### PR TITLE
Refactors trln/local toggle for accessibility. Fixes TD-1403.

### DIFF
--- a/app/assets/javascripts/trln_argon/results_count_for_toggle.js
+++ b/app/assets/javascripts/trln_argon/results_count_for_toggle.js
@@ -11,6 +11,6 @@ Blacklight.onLoad(function() {
     }
   }
 
-  fetch_and_display_toggle_count($('.blacklight-catalog-index #trln-toggle .toggle-trln label'));
-  fetch_and_display_toggle_count($('.blacklight-trln-index #trln-toggle .toggle-local label'));
+  fetch_and_display_toggle_count($('.blacklight-catalog-index #trln-toggle .toggle-trln .toggle-label'));
+  fetch_and_display_toggle_count($('.blacklight-trln-index #trln-toggle .toggle-local .toggle-label'));
 });

--- a/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
+++ b/app/assets/stylesheets/trln_argon/trln_argon_shared.scss
@@ -657,226 +657,125 @@ ul.blacklight-facet-checkboxes {
   color: $secondary-color;
 }
 
-
+/* TRLN vs. Local Scope Toggle */
+/* --------------------------- */
 #viewAllResults {
-
-  text-align: center;
-  margin-bottom: 1em;
-
-  .toggle {
-
-    display: inline-block;
-    width: 45%;
-    overflow: hidden;
-
-    a {
-      display: block;
+  .toggle-wrapper {
+    @include media-breakpoint-down(md) {
+      display: flex;
+      justify-content: center;
     }
+  }
 
-    label {
-      display: none;
-      cursor: pointer;
+  .toggle-logo {
+    border-radius: var(--bs-border-radius);
+    border: var(--bs-border-width) solid var(--bs-border-color-translucent);
+    .icon-wrapper {
+      width: 26px;
+      height: 40px;
+      background: transparent no-repeat left;
     }
+  }
 
-    &.toggle-local {
-      text-align: right;
-      margin-right: -2px;
-    }
-
-    &.toggle-trln {
-      text-align: left;
-      margin-left: -2px;
-    }
-
-    .btn-outline-secondary {
-
-      &:hover,
-      &:not(:disabled):not(.disabled):active,
-      &:focus {
-        color: #333;
-        background-color: #e6e6e6;
-        border-color: #adadad;
+  .toggle button {
+    &.active, &:active {
+      .toggle-logo {
+        @include button-variant($primary, $primary);
+        background: var(--bs-btn-bg);
       }
     }
 
+    &:hover:not(.active):not(:active), {
+      .toggle-logo {
+        background-color: var(--bs-secondary-bg-subtle);
+      }
+    }
   }
 
-  .icon-wrapper {
-    width: 26px;
-    height: 40px;
-    display: block;
+  .toggle-local {
+    .toggle-logo {
+      @include media-breakpoint-up(md) {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+      @include media-breakpoint-down(md) {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+    }
+    .icon-wrapper {
+      background-image: image_url($institution-icon);
+    }
   }
 
-  #toggle-trln-btn-top,
-  #toggle-local-btn-top,
-  #toggle-trln-btn-bottom,
-  #toggle-local-btn-bottom {
-    padding-left: 24px;
-    padding-right: 24px;
+  .toggle-trln {
+    .toggle-logo {
+      @include media-breakpoint-up(md) {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+      }
+      @include media-breakpoint-down(md) {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
+    }
+    .icon-wrapper {
+      background-image: image_url($trln-icon-inverted);
+    }
   }
 
-  #toggle-trln-btn-top,
-  #toggle-trln-btn-bottom {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+  .toggle-label {
+    line-height: 1.1;
+    font-weight: normal;
+    text-decoration: none;
+    color: $primary-link-color;
+    @include media-breakpoint-down(md) {
+      display: none !important;
+    }
   }
 
-  #toggle-local-btn-top,
-  #toggle-local-btn-bottom {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  #toggle-trln-btn-top .icon-wrapper,
-  #toggle-trln-btn-bottom .icon-wrapper {
-    background: transparent image_url($trln-icon-inverted) no-repeat left;
-  }
-
-  #toggle-local-btn-top .icon-wrapper,
-  #toggle-local-btn-bottom .icon-wrapper {
-    background: transparent image_url($institution-icon) no-repeat left;
+  button.active .toggle-label {
+    font-weight: bold;
+    color: #767676;
   }
 
   body.blacklight-catalog & {
-
-    #toggle-trln-btn-top .icon-wrapper,
-    #toggle-trln-btn-bottom .icon-wrapper {
-      background: transparent image_url($trln-icon) no-repeat left;
+    .toggle-local .icon-wrapper {
+      background-image: image_url($institution-icon-inverted);
     }
 
-    #toggle-local-btn-top .icon-wrapper,
-    #toggle-local-btn-bottom .icon-wrapper {
-      background: transparent image_url($institution-icon-inverted) no-repeat left;
+    .toggle-trln .icon-wrapper {
+      background-image: image_url($trln-icon);
     }
-
   }
-
-}
-
-@include media-breakpoint-up(md) {
-
-  #viewAllResults {
-
-    text-align: left;
-
-    .toggle {
-
-      display: block;
-      width: 100%;
-      overflow: hidden;
-
-      &.toggle-local,
-      &.toggle-trln {
-        margin: 0;
-      }
-
-      &.toggle-local {
-        text-align: left;
-      }
-
-      .btn {
-        margin-right: 7px;
-      }
-
-      #toggle-trln-btn-top,
-      #toggle-local-btn-top,
-      #toggle-trln-btn-bottom,
-      #toggle-local-btn-bottom {
-        padding-left: 12px;
-        padding-right: 12px;
-        display: inline-block;
-      }
-
-      #toggle-trln-btn-top,
-      #toggle-trln-btn-bottom {
-        border-radius: 4px;
-      }
-
-      #toggle-local-btn-top,
-      #toggle-local-btn-bottom {
-        border-radius: 4px;
-      }
-
-      label {
-        max-width: calc(100% - 65px);
-        line-height: 1.1;
-        display: inline-block;
-        vertical-align: middle;
-        font-weight: normal;
-        color: #767676;
-
-        &.active {
-          font-weight: bold;
-          color: $primary-link-color;
-        }
-
-      }
-
-      a:hover label {
-        color: $primary-link-color;
-      }
-
-    }
-
-  }
-
 }
 
 #viewAllResultsEnd {
-
-  margin-top: 1em;
-
   .toggle-wrapper {
-    display: table;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .toggle-logo {
+    display: none !important;
   }
 
-  .btn {
-    display: none;
+  .toggle-divider {
+    border-right: 2px solid var(--bs-border-color);
+    min-height: 30px;
   }
 
-  .toggle {
-    width: 45%;
-    display: table-cell;
-    vertical-align: middle;
-
-    &.toggle-local {
-      text-align: right;
-      border-right: 2px solid #ccc;
-      padding-right: 2px;
-    }
-
-    &.toggle-trln {
-      text-align: left;
-    }
-
-    label {
-      padding: 10px;
-      cursor: pointer;
-    }
-
-    a:hover label {
-      color: $primary-link-color;
-      text-decoration: underline;
-    }
-
-  }
-
-  label {
-
-    line-height: 1.2;
+  .toggle-label {
+    line-height: 1.1;
     font-weight: normal;
-    color: #767676;
-
-    &.active {
-      font-weight: bold;
-      color: $primary-link-color;
-    }
-
+    color: $primary-link-color;
   }
 
+  button.active .toggle-label {
+    font-weight: bold;
+    color: #767676;
+  }
 }
-
-
 
 /* =============== */
 /* ELEMENTS        */

--- a/app/components/trln_argon/search/sidebar_component.html.erb
+++ b/app/components/trln_argon/search/sidebar_component.html.erb
@@ -10,7 +10,7 @@
 </div>
 
 <div id="trln-toggle" class="sidenav facets top-panel-heading">
-  <div id="viewAllResults" class="clearfix" role="navigation" aria-label="Searching (context)">
+  <div id="viewAllResults" class="mb-2" role="navigation" aria-label="Searching (context)">
     <%= render 'catalog/local_filter',
               filter_label_id: 'localFilterLabelFacets',
               local_button_id: 'toggle-local-btn-top',

--- a/app/views/catalog/_local_filter.html.erb
+++ b/app/views/catalog/_local_filter.html.erb
@@ -6,26 +6,32 @@
 <% query_state.delete('page') %>
 <% query_state.fetch('f', {}).delete(TrlnArgon::Fields::LOCATION_HIERARCHY_FACET.to_s) %>
 
-<div class="toggle toggle-local">
-  <%= button_tag(type: "button", id: local_button_id, class: "btn btn-md #{local_search_button_class}",
-                title: "#{t('trln_argon.local_filter.search_verb')} #{t('trln_argon.local_filter.searching_local', local_institution_name: institution_long_name)}",
-                onclick: "window.location='#{search_catalog_path(query_state)}'") do %>
-    <span class="visually-hidden">icon</span><span class="icon-wrapper"></span>
-  <% end %>
+<div class="toggle-wrapper">
+  <div class="toggle toggle-local">
+    <%= button_tag(type: "button", id: local_button_id, class: "btn btn-link d-flex p-0 text-decoration-none border-0 #{local_search_button_class}",
+                  title: "#{t('trln_argon.local_filter.search_verb')} #{t('trln_argon.local_filter.searching_local', local_institution_name: institution_long_name)}",
+                  onclick: "window.location='#{search_catalog_path(query_state)}'") do %>
+      <div class="toggle-logo py-2 px-3">
+        <div class="icon-wrapper"></div>
+      </div>
+      <div id="<%= local_button_id %>-label" class="toggle-label text-start d-flex align-self-center ms-2 pe-2" data-count-only-path="<%= trln_argon.catalog_count_only_path(query_state) %>">
+        <%= t('trln_argon.local_filter.searching_local', local_institution_name: institution_long_name) %>
+      </div>
+    <% end %>
+  </div>
 
-  <%= label_tag(local_button_id, t('trln_argon.local_filter.searching_local', local_institution_name: institution_long_name),
-                class: "#{local_search_button_label_class}",
-                data: { count_only_path: trln_argon.catalog_count_only_path(query_state) }) %>
-</div>
+  <div class="toggle-divider"></div>
 
-<div class="toggle toggle-trln">
-  <%= button_tag(type: "button", id: trln_button_id, class: "btn btn-md #{trln_search_button_class}",
-                title: "#{t('trln_argon.local_filter.search_verb')} #{t('trln_argon.local_filter.searching_trln')}",
-                onclick: "window.location='#{search_trln_path(query_state)}'") do %>
-    <span class="visually-hidden">icon</span><span class="icon-wrapper"></span>
-  <% end %>
-
-<%= label_tag(trln_button_id, t('trln_argon.local_filter.searching_trln'),
-              class: "#{trln_search_button_label_class}",
-              data: { count_only_path: trln_argon.trln_count_only_path(query_state) }) %>
+  <div class="toggle toggle-trln">
+    <%= button_tag(type: "button", id: trln_button_id, class: "btn btn-link d-flex p-0 text-decoration-none border-0 #{trln_search_button_class}",
+                  title: "#{t('trln_argon.local_filter.search_verb')} #{t('trln_argon.local_filter.searching_trln')}",
+                  onclick: "window.location='#{search_trln_path(query_state)}'") do %>
+      <div class="toggle-logo py-2 px-3">
+        <div class="icon-wrapper"></div>
+      </div>
+      <div id="<%= trln_button_id %>-label" class="toggle-label text-start d-flex align-self-center ms-2 pe-2" data-count-only-path="<%= trln_argon.trln_count_only_path(query_state) %>">
+        <%= t('trln_argon.local_filter.searching_trln') %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/lib/trln_argon/trln_controller_behavior.rb
+++ b/lib/trln_argon/trln_controller_behavior.rb
@@ -6,8 +6,6 @@ module TrlnArgon
       helper_method :advanced_search_url
       helper_method :local_search_button_class
       helper_method :trln_search_button_class
-      helper_method :local_search_button_label_class
-      helper_method :trln_search_button_label_class
       helper_method :no_results_escape_href_url
       helper_method :filter_scope_name
       helper_method :url_for_document
@@ -64,18 +62,10 @@ module TrlnArgon
       end
 
       def local_search_button_class
-        'btn-outline-secondary'
-      end
-
-      def trln_search_button_class
-        'btn-primary active'
-      end
-
-      def local_search_button_label_class
         ''
       end
 
-      def trln_search_button_label_class
+      def trln_search_button_class
         'active'
       end
 

--- a/lib/trln_argon/view_helpers/search_scope_toggle_helper.rb
+++ b/lib/trln_argon/view_helpers/search_scope_toggle_helper.rb
@@ -10,18 +10,10 @@ module TrlnArgon
       end
 
       def local_search_button_class
-        'btn-primary active'
-      end
-
-      def trln_search_button_class
-        'btn-outline-secondary'
-      end
-
-      def local_search_button_label_class
         'active'
       end
 
-      def trln_search_button_label_class
+      def trln_search_button_class
         ''
       end
 

--- a/spec/lib/trln_argon/trln_controller_behavior_spec.rb
+++ b/spec/lib/trln_argon/trln_controller_behavior_spec.rb
@@ -30,29 +30,15 @@ describe TrlnArgon::TrlnControllerBehavior do
 
   describe '#local_search_button_class' do
     it 'sets the search button class' do
-      expect(mock_controller.helpers.local_search_button_class).to eq(
-        'btn-outline-secondary'
-      )
+      expect(mock_controller.helpers.local_search_button_class).to eq('')
     end
   end
 
   describe '#trln_search_button_class' do
     it 'sets the TRLN search button class' do
       expect(mock_controller.helpers.trln_search_button_class).to eq(
-        'btn-primary active'
+        'active'
       )
-    end
-  end
-
-  describe '#local_search_button_label_class' do
-    it 'sets the search button label class' do
-      expect(mock_controller.helpers.local_search_button_label_class).to eq('')
-    end
-  end
-
-  describe '#trln_search_button_label_class' do
-    it 'sets the TRLN search button label class' do
-      expect(mock_controller.helpers.trln_search_button_label_class).to eq('active')
     end
   end
 end

--- a/spec/lib/trln_argon/view_helpers/search_scope_toggle_helper_spec.rb
+++ b/spec/lib/trln_argon/view_helpers/search_scope_toggle_helper_spec.rb
@@ -13,25 +13,13 @@ describe TrlnArgon::ViewHelpers::SearchScopeToggleHelper, type: :helper do
 
   describe '#local_search_button_class' do
     it 'returns the expected class' do
-      expect(helper.local_search_button_class).to eq('btn-primary active')
+      expect(helper.local_search_button_class).to eq('active')
     end
   end
 
   describe '#trln_search_button_class' do
     it 'returns the expected class' do
-      expect(helper.trln_search_button_class).to eq('btn-outline-secondary')
-    end
-  end
-
-  describe '#local_search_button_label_class' do
-    it 'returns the expected class' do
-      expect(helper.local_search_button_label_class).to eq('active')
-    end
-  end
-
-  describe '#trln_search_button_label_class' do
-    it 'returns the expected class' do
-      expect(helper.trln_search_button_label_class).to eq('')
+      expect(helper.trln_search_button_class).to eq('')
     end
   end
 end


### PR DESCRIPTION
- Removes label element, not appropriate for buttons so WAVE flags as violation
- Reduces CSS complexity by using flexbox & BS5 styles
- Improves keyboard accessibility; focus ring now surrounds focused button
- Makes the element look more like a connected toggle, esp. when vertically stacked
- Removes unused cruft
- Restyles so the present scope is gray and the scope you can toggle to looks like a link (was backward before)


### Before
<img width="238" alt="Screenshot 2024-12-17 at 11 53 07 AM" src="https://github.com/user-attachments/assets/60edd782-8d89-4a8c-bd24-56062ae3784b" />

<img width="251" alt="Screenshot 2024-12-17 at 11 53 54 AM" src="https://github.com/user-attachments/assets/9a4263dd-b384-4993-8cf3-30175894f31a" />

<img width="677" alt="Screenshot 2024-12-17 at 11 57 05 AM" src="https://github.com/user-attachments/assets/0956a4f2-784b-493d-b9d7-6fc30ec5eace" />


### After
<img width="228" alt="Screenshot 2024-12-17 at 11 53 16 AM" src="https://github.com/user-attachments/assets/1dffe1b0-9672-4aa5-b952-178a8f919161" />

<img width="249" alt="Screenshot 2024-12-17 at 11 54 04 AM" src="https://github.com/user-attachments/assets/70540b56-bdda-4c61-b44e-9da3b768ab8c" />

