### PR TITLE
Fix masthead a11y warning; remove duplicate link. Fixes TD-1399.

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -3,11 +3,11 @@
 
 <nav class="navbar navbar-expand-md navbar-light bg-light topbar" role="navigation" aria-label="Masthead">
   <div class="<%= container_classes %>">
-    <%= link_to application_name, root_path, class: 'mb-0 navbar-brand navbar-logo' %>
+    <%= link_to inst_long, root_path, class: 'mb-0 navbar-brand navbar-logo' %>
+
     <button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <%= link_to content_tag(:span, inst_long, class: "visually-hidden"), root_path, class: "navbar-brand" %>
 
     <div class="collapse navbar-collapse justify-content-md-end" id="user-util-collapse">
       <%= render 'shared/user_util_links' %>


### PR DESCRIPTION
- fixes WAVE warning: adjacent links go to same URL
- there was an unwanted duplicate navbar-brand link; this commit consolidates.