### PR TITLE
Fix skip link display during keyboard navigation. Fixes TD-1412.

### DIFF
--- a/app/components/blacklight/skip_link_component.html.erb
+++ b/app/components/blacklight/skip_link_component.html.erb
@@ -1,9 +1,0 @@
-<%# TRLN override. Remove Bootstrap 4 sr-only classes. This override can be removed with the next release of Blacklight, as
-as they've been removed on the main branch. %>
-<nav id="skip-link" role="navigation" class="visually-hidden-focusable" aria-label="<%= t('blacklight.skip_links.label') %>">
-  <div class="container-xl">
-    <%= link_to_search %>
-    <%= link_to_main %>
-    <%= content %>
-  </div>
-</nav>

--- a/app/components/trln_argon/skip_link_component.html.erb
+++ b/app/components/trln_argon/skip_link_component.html.erb
@@ -1,0 +1,9 @@
+<%# TRLN override. Remove Bootstrap 4 sr-only classes. This override can be removed in BL9 -%>
+<%# https://github.com/projectblacklight/blacklight/blob/release-8.x/app/components/blacklight/skip_link_component.html.erb -%>
+<nav id="skip-link" role="navigation" class="visually-hidden-focusable" aria-label="<%= t('blacklight.skip_links.label') %>">
+  <div class="container-xl">
+    <%= link_to_main %>
+    <%= link_to_search %>
+    <%= content %>
+  </div>
+</nav>

--- a/app/components/trln_argon/skip_link_component.rb
+++ b/app/components/trln_argon/skip_link_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module TrlnArgon
+  class SkipLinkComponent < Blacklight::SkipLinkComponent
+  end
+end

--- a/lib/trln_argon/controller_override.rb
+++ b/lib/trln_argon/controller_override.rb
@@ -36,6 +36,9 @@ module TrlnArgon
         # https://github.com/projectblacklight/blacklight/issues/3154
         config.search_state_fields << %i[id debug doc_ids]
 
+        # TRLN custom skip link display.
+        config.skip_link_component = TrlnArgon::SkipLinkComponent
+
         # Sets the sidebar component for the index view in the TrlnArgon configuration.
         config.index.sidebar_component = TrlnArgon::Search::SidebarComponent
         config.index.document_component = TrlnArgon::DocumentComponent


### PR DESCRIPTION
- subclass the BL core SkipLinkComponent and configure trln_argon to use ours
- note legacy BS4 .sr-only is problematic due to css in font-awesome-rails gem
- refactors fix from #448 so it uses a subclassed component